### PR TITLE
Use version 0.16.0 of the kubeseal binary to encrypt secrets.

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -1,5 +1,5 @@
 FROM abihf/wget:latest AS kubeseal-downloader
-RUN wget https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.11.0/kubeseal-linux-amd64 && \
+RUN wget https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.16.0/kubeseal-linux-amd64 && \
     mv kubeseal-linux-amd64 /tmp/kubeseal
 
 FROM python:3.9-alpine

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
 This is a python based webapp for using Bitnami-Sealed-Secrets in a web-gui.
 
 This app uses the kubeseal binary of the original project: <https://github.com/bitnami-labs/sealed-secrets>
+Currently using version `0.16.0` of the kubeseal-binary.
+
 
 The docker image can be found here: https://hub.docker.com/repository/docker/kubesealwebgui/kubeseal-webgui
 


### PR DESCRIPTION
Fixes #86 