### PR TITLE
Change image pull policy default

### DIFF
--- a/chart/kubeseal-webgui/values.yaml
+++ b/chart/kubeseal-webgui/values.yaml
@@ -15,7 +15,7 @@ ui:
     repository: kubesealwebgui/ui
     tag: 2.1.1
 image:
-  pullPolicy: IfNotPresent
+  pullPolicy: Always
 
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
Changed image pull policy to 'Always'. Makes development of the chart
easier and ensures that the most current image version is used in
general.