### PR TITLE
add support for kubeseal certificate retrieval.

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -4,7 +4,8 @@ ARG KUBESEAL_VERSION=0.16.0
 ENV PORT=5000 \
     HOST=0.0.0.0 \
     APP_HOME=/kubeseal-webgui
-ENV KUBESEAL_BINARY=${APP_HOME}/kubeseal
+ENV KUBESEAL_BINARY=${APP_HOME}/bin/kubeseal \
+    PATH="${APP_HOME}/bin:${PATH}"
 
 WORKDIR ${APP_HOME}
 COPY api/requirements.txt .

--- a/api/bin/kubeseal-fetch.sh
+++ b/api/bin/kubeseal-fetch.sh
@@ -1,0 +1,19 @@
+#!/bin/sh -eu
+
+: "${KUBESEAL_BINARY:=/kubeseal-webgui/bin/kubeseal}"
+: "${KUBESEAL_CERT:=/kubeseal-webgui/cert/kubeseal-cert.pem}"
+: "${KUBESEAL_CONTROLLER_NAME:=sealed-secrets-controller}"
+: "${KUBESEAL_CONTROLLER_NAMESPACE:=kube-system}"
+
+if test $# -gt 0; then
+  KUBESEAL_CERT="$1"
+fi
+
+CERT_DIR=$(dirname "$KUBESEAL_CERT")
+
+mkdir -p "$CERT_DIR"
+
+env -C "$CERT_DIR" "${KUBESEAL_BINARY}" --fetch-cert \
+  --controller-name "$KUBESEAL_CONTROLLER_NAME" \
+  --controller-namespace "${KUBESEAL_CONTROLLER_NAMESPACE}" \
+| tee "$KUBESEAL_CERT" >/dev/null

--- a/chart/kubeseal-webgui/README.md
+++ b/chart/kubeseal-webgui/README.md
@@ -48,4 +48,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `route.hostname`                          | Set Hostname of the route                      | `""`                                                    |
 | `route.tls.termination`                   | TLS Termination of the route                   | `""`                                                    |
 | `route.tls.insecureEdgeTerminationPolicy` | TLS insecureEdgeTerminationPolicy of the route | `""`                                                    |
+| `sealedSecrets.autoFetchCert`             | Load the cert from the Controller on start     | `false`                                                 |
+| `sealedSecrets.controllerName`            | Deployment name of the Controller              | `sealed-secrets-controller`                             |
+| `sealedSecrets.controllerNamespace`       | Namespace the Controller resides in            | `kube-system`                                           |
 | `sealedSecrets.cert`                      | Public-Key of your SealedSecrets controller    | `""`                                                    |

--- a/chart/kubeseal-webgui/ci/fetch.yaml
+++ b/chart/kubeseal-webgui/ci/fetch.yaml
@@ -1,0 +1,6 @@
+---
+
+sealedSecrets:
+  autoFetchCert: true
+  controllerName: seal
+  controllerNamespace: secrets

--- a/chart/kubeseal-webgui/templates/configmap.yaml
+++ b/chart/kubeseal-webgui/templates/configmap.yaml
@@ -5,8 +5,10 @@ metadata:
   labels:
   {{- include "kubeseal-webgui.labels" . | nindent 4 }}
 data:
+{{- if not .Values.sealedSecrets.autoFetchCert }}
   kubeseal-cert.pem:
 {{- toYaml .Values.sealedSecrets.cert | nindent 4 }}
+{{- end }}
   config.json: |-
     { 
       "api_url": {{ .Values.api.url | quote }},

--- a/chart/kubeseal-webgui/templates/deployment.yaml
+++ b/chart/kubeseal-webgui/templates/deployment.yaml
@@ -17,6 +17,21 @@ spec:
       {{- if .Values.serviceaccount.create }}
       serviceAccountName: kubeseal-webgui
       {{- end }}
+      {{- if .Values.sealedSecrets.autoFetchCert }}
+      initContainers:
+        - name: "fetch-cert"
+          image: "{{ .Values.api.image.repository }}:{{ .Values.api.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: [ "/kubeseal-webgui/bin/kubeseal-fetch.sh", "/certs/kubeseal-cert.pem" ]
+          env:
+            - name: KUBESEAL_CONTROLLER_NAME
+              value: {{ .Values.sealedSecrets.controllerName | quote }}
+            - name: KUBESEAL_CONTROLLER_NAMESPACE
+              value: {{ .Values.sealedSecrets.controllerNamespace | quote }}
+          volumeMounts:
+            - mountPath: /certs
+              name: sealed-secrets-certs
+      {{- end }}
       containers:
         - name: "api"
           image: "{{ .Values.api.image.repository }}:{{ .Values.api.image.tag }}"
@@ -41,9 +56,14 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
+           {{- if .Values.sealedSecrets.autoFetchCert }}
+            - name: sealed-secret-certs
+              mountPath: /kubeseal-webgui/cert
+           {{- else }}
             - name: sealed-secret-configmap
               mountPath: /kubeseal-webgui/cert/kubeseal-cert.pem
               subPath: kubeseal-cert.pem
+           {{- end }}
         - name: "ui"
           image: "{{ .Values.ui.image.repository }}:{{ .Values.ui.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -66,6 +86,10 @@ spec:
               mountPath: /usr/share/nginx/html/config.json
               subPath: config.json
       volumes:
+        {{- if .Values.sealedSecrets.autoFetchCert }}
+        - name: sealed-secrets-certs
+          emptyDir: {}
+        {{- end }}
         - name: sealed-secret-configmap
           configMap:
             name: {{ include "kubeseal-webgui.fullname" . }}

--- a/chart/kubeseal-webgui/values.yaml
+++ b/chart/kubeseal-webgui/values.yaml
@@ -44,6 +44,9 @@ route:
     insecureEdgeTerminationPolicy: None
 
 sealedSecrets:
+  autoFetchCert: false
+  controllerName: sealed-secrets-controller
+  controllerNamespace: kube-system
   ## Public Certificate of your Sealed-Secrets Controller.
   ## Login to your cluster with kubectl.
   ## Run kubeseal --fetch-cert --controller-name <your-sealed-secrets-controller> --controller-namespace <sealed-secrets-controller-namespace>


### PR DESCRIPTION
instead of using a configmap, the certificate is fetched from
the controller upon deployment.

closes #40