### PR TITLE
render API DTOs as objects not strings.

### DIFF
--- a/api/app/config.py
+++ b/api/app/config.py
@@ -1,5 +1,4 @@
 """Provides REST-API and kubeseal-cli specific functionality."""
-import json
 import logging
 import subprocess
 
@@ -41,9 +40,8 @@ def get_kubeseal_version() -> str:
     return str(version).split(":")[1].replace('"', "").lstrip()
 
 
-def get_app_config():
-    """Return the app configs in json format."""
-    config = {}
-    config["kubeseal_version"] = get_kubeseal_version()
-
-    return json.dumps(config)
+def get_app_config() -> dict[str, str]:
+    """Return the app configs dict."""
+    return {
+        'kubeseal_version': get_kubeseal_version(),
+    }

--- a/api/app/kubernetes.py
+++ b/api/app/kubernetes.py
@@ -1,5 +1,4 @@
 """Provides REST-API and kubeseal-cli specific functionality."""
-import json
 import logging
 
 from flask import abort
@@ -13,7 +12,7 @@ class KubernetesNamespacesEndpoint(Resource):
     """Provide REST-API for sealing sensitive data."""
 
     @classmethod
-    def get(cls) -> str:
+    def get(cls) -> list[str]:
         """Retrieve cluster namespaces."""
         try:
             return get_incluster_namespaces()
@@ -21,8 +20,8 @@ class KubernetesNamespacesEndpoint(Resource):
             abort(500, "Can't get namespaces from server")
 
 
-def get_incluster_namespaces() -> str:
-    """Retrieve all namespaces from current kubernetes cluster as JSON-Array."""
+def get_incluster_namespaces() -> list[str]:
+    """Retrieve a list of namespaces from current kubernetes cluster."""
     config.load_incluster_config()
     namespaces_list = []
 
@@ -36,4 +35,4 @@ def get_incluster_namespaces() -> str:
         LOGGER.warn("No valid namespace list available via %s", namespaces)
 
     LOGGER.debug("Namespaces list %s", namespaces_list)
-    return json.dumps(namespaces_list)
+    return namespaces_list

--- a/ui/src/components/AppConfig.vue
+++ b/ui/src/components/AppConfig.vue
@@ -42,7 +42,7 @@ export default {
           this.fetchConfigsSuccessful = false
         }
         let configs = await response.json();
-        this.configs = JSON.parse(configs);
+        this.configs = configs;
         this.configs.kubeseal_webgui_ui_version = kubeseal_webgui_ui_version;
         this.configs.kubeseal_webgui_api_version = kubeseal_webgui_api_version;
       } catch (error) {

--- a/ui/src/components/Secrets.vue
+++ b/ui/src/components/Secrets.vue
@@ -216,9 +216,7 @@ export default {
         let apiUrl = data["api_url"];
 
         response = await fetch(`${apiUrl}/namespaces`);
-
-        let availableNamespaces = await response.json();
-        this.namespaces = JSON.parse(availableNamespaces);
+        this.namespaces = await response.json();
       } catch (error) {
         this.errorMessage = error;
       }


### PR DESCRIPTION
flask_restful supports content negotiation and DTO rendering and
does not rely on the controller rendering the response as JSON.
this change causes all API methods to return structured objects
instead of string-serialized objects.