### PR TITLE
Disable thrashcan icon, when no secrets are given

### DIFF
--- a/ui/src/components/Secrets.vue
+++ b/ui/src/components/Secrets.vue
@@ -94,10 +94,11 @@
             </b-col>
             <b-col cols="1">
               <b-button block variant="link"
+                :disabled="hasNoSecrets()"
                 ><b-icon
                   icon="trash"
                   aria-hidden="true"
-                  v-on:click="secrets.splice(counter, 1)"
+                  v-on:click="removeSecret(counter)"
                 ></b-icon
               ></b-button>
             </b-col>
@@ -282,6 +283,21 @@ export default {
       let sealedSecretContent = sealedSecretElement.innerText.trim();
       navigator.clipboard.writeText(sealedSecretContent);
     },
+    hasNoSecrets: function () {
+      if (this.secrets.length > 1) {
+        return false;
+      }
+      let secret = this.secrets[0];
+      return secret.key === '' && secret.value === '';
+    },
+    removeSecret: function (counter) {
+      if (this.secrets.length > 1) {
+        this.secrets.splice(counter, 1)
+      } else {
+        this.secrets[0].key = '';
+        this.secrets[0].value = '';
+      }
+    }
   },
   beforeMount() {
     this.fetchNamespaces();


### PR DESCRIPTION
Change behaviour of trashcan icon to not remove the last secret, but to set it to empty.

This should fix #137