### PR TITLE
Use utf-8 as encoding in Popen

### DIFF
--- a/api/app/config.py
+++ b/api/app/config.py
@@ -29,6 +29,7 @@ def get_kubeseal_version() -> str:
         [binary, "--version"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
+        encoding="utf-8",
     )
     output, error = kubeseal_subprocess.communicate()
     if error:
@@ -36,7 +37,7 @@ def get_kubeseal_version() -> str:
         LOGGER.error(error_message)
         raise RuntimeError(error_message)
 
-    version = "".join(output.decode("utf-8").split("\n"))
+    version = "".join(output.split("\n"))
 
     return str(version).split(":")[1].replace('"', "").lstrip()
 

--- a/api/app/kubeseal.py
+++ b/api/app/kubeseal.py
@@ -111,17 +111,16 @@ def run_kubeseal_command(cleartext_secret_tuple, secret_namespace, secret_name):
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
+        encoding="utf-8",
     )
-    output, error = kubeseal_subprocess.communicate(
-        input=cleartext_secret.encode("utf-8")
-    )
+    output, error = kubeseal_subprocess.communicate(input=cleartext_secret)
 
     if error:
         error_message = f"Error in run_kubeseal: {error}"
         LOGGER.error(error_message)
         raise RuntimeError(error_message)
 
-    sealed_secret = "".join(output.decode("utf-8").split("\n"))
+    sealed_secret = "".join(output.split("\n"))
     return {"key": cleartext_secret_tuple["key"], "value": sealed_secret}
 
 


### PR DESCRIPTION
That way, we know the stdout and stderr are already decoded by the stdlib and we can use them directly.