### PR TITLE
Use node:lts for building the UI. python3 is needed whichb is include…

### DIFF
--- a/Dockerfile.ui
+++ b/Dockerfile.ui
@@ -1,4 +1,4 @@
-FROM node:lts-alpine AS ui-build-stage
+FROM node:lts AS ui-build-stage
 COPY ui/ /ui
 WORKDIR /ui
 RUN npm install --legacy-peer-deps && npm run build


### PR DESCRIPTION
…d in the lts version of node