### PR TITLE
Use proper models for the api provided by fastapi

### DIFF
--- a/api/kubeseal_webgui_api/routers/config.py
+++ b/api/kubeseal_webgui_api/routers/config.py
@@ -1,22 +1,20 @@
 import logging
-from typing import Dict
 
 import fastapi
 
 from kubeseal_webgui_api.app_config import settings
+from kubeseal_webgui_api.routers.models import WebGuiConfig
 
 LOGGER = logging.getLogger("kubeseal-webgui")
 router = fastapi.APIRouter()
 
 
-@router.get("/config")
-def get_configs() -> Dict[str, str]:
+@router.get("/config", response_model=WebGuiConfig)
+def get_configs() -> WebGuiConfig:
     if settings.mock_enabled:
-        return {"kubeseal_version": "0.1.0"}
+        return WebGuiConfig(kubeseal_version="0.1.0")
     try:
-        return {
-            "kubeseal_version": settings.kubeseal_version,
-        }
+        return WebGuiConfig(kubeseal_version=settings.kubeseal_version)
     except RuntimeError:
         raise fastapi.HTTPException(
             status_code=500, detail="Failed to retrieve application configs."

--- a/api/kubeseal_webgui_api/routers/kubernetes.py
+++ b/api/kubeseal_webgui_api/routers/kubernetes.py
@@ -18,7 +18,7 @@ else:
     namespace_resolver = kubernetes_namespaces_resolver
 
 
-@router.get("/namespaces")
+@router.get("/namespaces", response_model=List[str])
 def get_namespaces() -> List[str]:
     try:
         return namespace_resolver()

--- a/api/kubeseal_webgui_api/routers/models.py
+++ b/api/kubeseal_webgui_api/routers/models.py
@@ -1,0 +1,57 @@
+from enum import Enum
+from typing import List, Optional
+
+from pydantic import BaseModel, root_validator
+
+
+def to_camel(value: str) -> str:
+    head, *tail = value.split("_")
+    return head + "".join(word.capitalize() for word in tail)
+
+
+class WebGuiConfig(BaseModel):
+    kubeseal_version: str
+
+    class Config:
+        alias_generator = to_camel
+        allow_population_by_field_name = True
+
+
+class KeyValuePair(BaseModel):
+    key: str
+    value: str
+
+
+class Secret(BaseModel):
+    key: str
+    value: Optional[str] = None
+    file: Optional[str] = None
+
+    @root_validator
+    @classmethod
+    def value_or_file_set(cls, values):
+        file, value = values.get("file"), values.get("value")
+        if file and value:
+            raise AssertionError("Only one field of 'value' or 'file' can be used")
+        if file is None and value is None:
+            raise AssertionError("One field of 'value' or 'file' has to be set")
+        return values
+
+
+class Scope(str, Enum):
+    STRICT = "strict"
+    CLUSTER_WIDE = "cluster-wide"
+    NAMESPACE_WIDE = "namespace-wide"
+
+    def needs_name(self):
+        return self not in (Scope.CLUSTER_WIDE, Scope.NAMESPACE_WIDE)
+
+    def needs_namespace(self):
+        return self is not Scope.CLUSTER_WIDE
+
+
+class Data(BaseModel):
+    secret: Optional[str]
+    namespace: Optional[str]
+    secrets: List[Secret]
+    scope: Optional[Scope]

--- a/api/tests/test_kubeseal_service.py
+++ b/api/tests/test_kubeseal_service.py
@@ -1,7 +1,5 @@
-import json
 import logging
 from os import environ
-from unittest.mock import patch
 
 import pytest
 from fastapi.testclient import TestClient

--- a/ui/nginx-default.conf
+++ b/ui/nginx-default.conf
@@ -18,7 +18,7 @@ server {
         root   /usr/share/nginx/html;
     }
 
-    location ~ /(secrets|namespaces|config)(/.*)?$ {
+    location ~ /(secrets|namespaces|config|docs)(/.*)?$ {
         proxy_pass http://localhost:5000;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;

--- a/ui/nginx-default.conf
+++ b/ui/nginx-default.conf
@@ -18,7 +18,7 @@ server {
         root   /usr/share/nginx/html;
     }
 
-    location ~ /(secrets|namespaces|config|docs)(/.*)?$ {
+    location ~ /(secrets|namespaces|config|docs|openapi.json)(/.*)?$ {
         proxy_pass http://localhost:5000;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;


### PR DESCRIPTION
That way, we have to do less checking ourselves and have a better documented /docs interface
to test and explore the api.