### PR TITLE
add .dockerignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+*
+.*
+!api/pyproject.toml
+!api/README.md
+!api/bin
+!api/config
+!api/kubeseal_webgui_api
+!ui/*

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,5 @@ chart/kubeseal-webgui/values-local.yaml
 test.sh
 test.yaml
 *.pyc
-.dockerignore
 .coverage
 .venv/


### PR DESCRIPTION
exclude everything from the docker build context except the API and UI sources. this will prevent unnecessary clutter ending up in the images.

closes #158