### PR TITLE
make route hostname optional

### DIFF
--- a/chart/kubeseal-webgui/templates/route-ui.yaml
+++ b/chart/kubeseal-webgui/templates/route-ui.yaml
@@ -11,7 +11,9 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
+{{- if ne .Values.route.hostname "" }}
   host: {{ .Values.route.hostname | quote }}
+{{- end }}
   to:
     kind: Service
     name: {{ include "kubeseal-webgui.fullname" . }}

--- a/chart/kubeseal-webgui/templates/route-ui.yaml
+++ b/chart/kubeseal-webgui/templates/route-ui.yaml
@@ -11,7 +11,7 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
-{{- if ne .Values.route.hostname "" }}
+{{- if .Values.route.hostname }}
   host: {{ .Values.route.hostname | quote }}
 {{- end }}
   to:


### PR DESCRIPTION
When sending <""> as value for route hostname, Openshift sets it correctly by itself. But ArgoCD still sees a diff, because the desired state would be <"">. By omitting it, ArgoCD does not see a diff and the app can sync successfully.