### PR TITLE
Configure vues own proxy module

### DIFF
--- a/ui/public/config.json
+++ b/ui/public/config.json
@@ -1,6 +1,6 @@
 {
-  "api_url" : "http://localhost:5000",
+  "api_url": "",
   "display_name": "Test",
-  "kubeseal_webgui_ui_version" : "2.1.0",
-  "kubeseal_webgui_api_version" : "2.1.0"
+  "kubeseal_webgui_ui_version": "2.1.0",
+  "kubeseal_webgui_api_version": "2.1.0"
 }

--- a/ui/vue.config.js
+++ b/ui/vue.config.js
@@ -1,5 +1,13 @@
 const { defineConfig } = require('@vue/cli-service')
 module.exports = defineConfig({
+  devServer: {
+    proxy: {
+      "^/(secrets|namespaces|config|docs|openapi.json)": {
+        target: "http://localhost:5000",
+        changeOrigin: false
+      }
+    }
+  },
   pluginOptions: {
     vuetify: {
       // https://github.com/vuetifyjs/vuetify-loader/tree/next/packages/vuetify-loader


### PR DESCRIPTION
that makes the use of api_url in the config.json mostly obsolete, as the dev environment looks like the prod one.

Vue will now route all requests to the api backend itself.