### PR TITLE
Change ownership of home to allow root group access

### DIFF
--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -55,6 +55,7 @@ jobs:
             --set resources=null \
             --set sealedSecrets.autoFetchCert=true \
             --set ui.image.tag=snapshot \
+            --set securityContext.runAsUser=1042 \
             chart/kubeseal-webgui \
           | kubectl apply \
             -f - \

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -21,11 +21,13 @@ FROM python:3.10-slim
 
 USER root
 
-RUN adduser --gid 0 --home /kubeseal-webgui --disabled-password app
-
-ARG KUBESEAL_VERSION=${KUBESEAL_VERSION}
 ARG APP_PATH="/kubeseal-webgui"
 ARG APP_PORT=5000
+ARG KUBESEAL_VERSION=${KUBESEAL_VERSION}
+
+RUN adduser --gid 0 --home "${APP_PATH}" --disabled-password app \
+    && chmod 0750 "${APP_PATH}"
+
 
 USER app
 

--- a/chart/kubeseal-webgui/templates/deployment.yaml
+++ b/chart/kubeseal-webgui/templates/deployment.yaml
@@ -16,6 +16,10 @@ spec:
       annotations:
         {{ toYaml .Values.annotations | nindent 8 }}
     spec:
+      {{- with .Values.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if .Values.serviceaccount.create }}
       serviceAccountName: kubeseal-webgui
       {{- end }}

--- a/kind-setup.sh
+++ b/kind-setup.sh
@@ -54,6 +54,7 @@ helm template \
     --set resources=null \
     --set sealedSecrets.autoFetchCert=true \
     --set ui.image.tag=snapshot \
+    --set securityContext.runAsUser=1042 \
     chart/kubeseal-webgui \
     | kubectl apply -f - --namespace kubeseal-webgui
 


### PR DESCRIPTION
In OpenShift all pods are run as a random user by default. Emulate a pseudo-random user in our end2end test and extend the helm chart to allow a custom securityContext.