### PR TITLE
Helm Chart Improvements

### DIFF
--- a/chart/kubeseal-webgui/Chart.yaml
+++ b/chart/kubeseal-webgui/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: kubeseal-webgui
 description: A Helm chart for installing kubeseal-webgui
-version: 5.1.5
+version: 5.2.0
 appVersion: 4.2.5

--- a/chart/kubeseal-webgui/README.md
+++ b/chart/kubeseal-webgui/README.md
@@ -24,40 +24,41 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Configuration
 
-| Parameter                                 | Description                                     | Default                          |
-| ----------------------------------------- | ----------------------------------------------- | -------------------------------- |
-| `replicaCount`                            | Number of nodes                                 | `1`                              |
-| `annotations`                             | Optional annotations for the pods               | `{}`                             |
-| `api.image.repository`                    | Image-Repository and name of the api image.     | `kubesealwebgui/api`             |
-| `api.image.tag`                           | Image Tag of the api image.                     | `4.2.5`                          |
-| `api.environment`                         | Additional env variables for the api image.     | `{}`                             |
-| `api.loglevel`                            | Loglevel for the api image.                     | `INFO`                           |
-| `ui.image.repository`                     | Image-Repository and name of the ui image.      | `kubesealwebgui/ui`              |
-| `ui.image.tag`                            | Image Tag of the ui image.                      | `4.2.5`                          |
-| `image.pullPolicy`                        | Image Pull Policy                               | `Always`                         |
-| `nameOverride`                            | Name-Override for the objects                   | `""`                             |
-| `fullnameOverride`                        | Fullname-Override for the objects               | `""`                             |
-| `serviceaccount.create`                   | Add serviceaccount for listing namespaces       | `true`                           |
-| `tolerations`                             | Add tolerations to the deployment.              | `[]`                             |
-| `affinity`                                | Add affinity rules to the deployment.           | `{}`                             |
-| `nodeSelector`                            | Add a nodeSelector to the deployment.           | `{}`                             |
-| `displayName`                             | Optional display name for the kubeseal instance | `""`                             |
-| `resources.limits.cpu`                    | Limits CPU                                      | `100m`                           |
-| `resources.limits.memory`                 | Limits memory                                   | `256Mi`                          |
-| `resources.requests.cpu`                  | Requests CPU                                    | `20m`                            |
-| `resources.requests.memory`               | Requests memory                                 | `20m`                            |
-| `ingress.enabled`                         | Enable an ingress route                         | `false`                          |
-| `ingress.annotations`                     | Additional annotations for the ingress object.  | `{}`                             |
-| `ingress.ingressClassName`                | Additional ingressClassName.                    | `""`                             |
-| `ingress.hostname`                        | The hostname for the ingress route              | `kubeseal-webgui.example.com`    |
-| `ingress.tls.enabled`                     | Enable TLS for the ingress route                | `false`                          |
-| `ingress.tls.secretName`                  | The secret name for private and public key      | `""`                             |
-| `route.enabled`                           | Deploy OpenShift route                          | `false`                          |
-| `route.hostname`                          | Set Hostname of the route                       | `""`                             |
-| `route.tls.termination`                   | TLS Termination of the route                    | `""`                             |
-| `route.tls.insecureEdgeTerminationPolicy` | TLS insecureEdgeTerminationPolicy of the route  | `""`                             |
-| `sealedSecrets.autoFetchCert`             | Load the cert from the Controller on start      | `false`                          |
-| `sealedSecrets.controllerName`            | Deployment name of the Controller               | `sealed-secrets-controller`      |
-| `sealedSecrets.controllerNamespace`       | Namespace the Controller resides in             | `kube-system`                    |
-| `sealedSecrets.cert`                      | Public-Key of your SealedSecrets controller     | `""`                             |
-| `api.environment`                         | Additional API environment variables            | `{}`                             |
+| Parameter                                 | Description                                       | Default                       |
+| ----------------------------------------- | ------------------------------------------------- | ----------------------------- |
+| `replicaCount`                            | Number of nodes                                   | `1`                           |
+| `annotations`                             | Optional annotations for the pods                 | `{}`                          |
+| `api.image.repository`                    | Image-Repository and name of the api image.       | `kubesealwebgui/api`          |
+| `api.image.tag`                           | Image Tag of the api image.                       | `4.2.5`                       |
+| `api.environment`                         | Additional env variables for the api image.       | `{}`                          |
+| `api.loglevel`                            | Loglevel for the api image.                       | `INFO`                        |
+| `ui.image.repository`                     | Image-Repository and name of the ui image.        | `kubesealwebgui/ui`           |
+| `ui.image.tag`                            | Image Tag of the ui image.                        | `4.2.5`                       |
+| `image.pullPolicy`                        | Image Pull Policy                                 | `Always`                      |
+| `nameOverride`                            | Name-Override for the objects                     | `""`                          |
+| `fullnameOverride`                        | Fullname-Override for the objects                 | `""`                          |
+| `customServiceAccountName`                | Optionallyn define your own serviceaccount to use | `true`                        |
+| `tolerations`                             | Add tolerations to the deployment.                | `[]`                          |
+| `affinity`                                | Add affinity rules to the deployment.             | `{}`                          |
+| `nodeSelector`                            | Add a nodeSelector to the deployment.             | `{}`                          |
+| `displayName`                             | Optional display name for the kubeseal instance   | `""`                          |
+| `resources.limits.cpu`                    | Limits CPU                                        | `100m`                        |
+| `resources.limits.memory`                 | Limits memory                                     | `256Mi`                       |
+| `resources.requests.cpu`                  | Requests CPU                                      | `20m`                         |
+| `resources.requests.memory`               | Requests memory                                   | `20m`                         |
+| `ingress.enabled`                         | Enable an ingress route                           | `false`                       |
+| `ingress.annotations`                     | Additional annotations for the ingress object.    | `{}`                          |
+| `ingress.ingressClassName`                | Additional ingressClassName.                      | `""`                          |
+| `ingress.hostname`                        | The hostname for the ingress route                | `kubeseal-webgui.example.com` |
+| `ingress.tls.enabled`                     | Enable TLS for the ingress route                  | `false`                       |
+| `ingress.tls.secretName`                  | The secret name for private and public key        | `""`                          |
+| `route.enabled`                           | Deploy OpenShift route                            | `false`                       |
+| `route.hostname`                          | Set Hostname of the route                         | `""`                          |
+| `route.tls.enabled`                       | Enable/Disable TLS for OpenShift Route            | `true`                        |
+| `route.tls.termination`                   | TLS Termination of the route                      | `""`                          |
+| `route.tls.insecureEdgeTerminationPolicy` | TLS insecureEdgeTerminationPolicy of the route    | `""`                          |
+| `sealedSecrets.autoFetchCert`             | Load the cert from the Controller on start        | `false`                       |
+| `sealedSecrets.controllerName`            | Deployment name of the Controller                 | `sealed-secrets-controller`   |
+| `sealedSecrets.controllerNamespace`       | Namespace the Controller resides in               | `kube-system`                 |
+| `sealedSecrets.cert`                      | Public-Key of your SealedSecrets controller       | `""`                          |
+| `api.environment`                         | Additional API environment variables              | `{}`                          |

--- a/chart/kubeseal-webgui/templates/clusterrole.yaml
+++ b/chart/kubeseal-webgui/templates/clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceaccount.create }}
+{{- if not .Values.customServiceAccountName }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/chart/kubeseal-webgui/templates/clusterrolebinding.yaml
+++ b/chart/kubeseal-webgui/templates/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceaccount.create }}
+{{- if not .Values.customServiceAccountName }}
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/chart/kubeseal-webgui/templates/deployment.yaml
+++ b/chart/kubeseal-webgui/templates/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ .Values.customServiceAccountName default "kubeseal-webgui" | quote }}
+      serviceAccountName: {{ .Values.customServiceAccountName | default "kubeseal-webgui" | quote }}
       {{- if .Values.tolerations }}
       tolerations:
       {{ toYaml .Values.tolerations | nindent 8 }}

--- a/chart/kubeseal-webgui/templates/deployment.yaml
+++ b/chart/kubeseal-webgui/templates/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ default "kubeseal-webgui" .Values.customServiceAccountName }}
+      serviceAccountName: {{ .Values.customServiceAccountName default "kubeseal-webgui" | quote }}
       {{- if .Values.tolerations }}
       tolerations:
       {{ toYaml .Values.tolerations | nindent 8 }}

--- a/chart/kubeseal-webgui/templates/deployment.yaml
+++ b/chart/kubeseal-webgui/templates/deployment.yaml
@@ -20,9 +20,7 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.serviceaccount.create }}
-      serviceAccountName: kubeseal-webgui
-      {{- end }}
+      serviceAccountName: {{ default "kubeseal-webgui" .Values.customServiceAccountName }}
       {{- if .Values.tolerations }}
       tolerations:
       {{ toYaml .Values.tolerations | nindent 8 }}

--- a/chart/kubeseal-webgui/templates/route-ui.yaml
+++ b/chart/kubeseal-webgui/templates/route-ui.yaml
@@ -20,8 +20,10 @@ spec:
     weight: 100
   port:
     targetPort: ui
+  {{- if .Values.route.tls.enabled }}
   tls:
     termination: {{ .Values.route.tls.termination }}
     insecureEdgeTerminationPolicy: {{ .Values.route.tls.insecureEdgeTerminationPolicy }}
+  {{- end }}
   wildcardPolicy: None
 {{- end }}

--- a/chart/kubeseal-webgui/templates/serviceaccount.yaml
+++ b/chart/kubeseal-webgui/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceaccount.create }}
+{{- if not .Values.customServiceAccountName }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/chart/kubeseal-webgui/values.yaml
+++ b/chart/kubeseal-webgui/values.yaml
@@ -25,7 +25,7 @@ fullnameOverride: ""
 # Optionally setup a display name for your kubeseal-webgui instance.
 displayName: ""
 
-# Set this value to specify a ServiceAccount who is allowed to list namespaces.
+# Set this value to specify a ServiceAccount that is allowed to list namespaces.
 # Leave empty to use the ServiceAccount shipped with this chart.
 # If you use a custom ServiceAccount it must be able to list namespaces in your cluster.
 customServiceAccountName: ""

--- a/chart/kubeseal-webgui/values.yaml
+++ b/chart/kubeseal-webgui/values.yaml
@@ -27,7 +27,7 @@ displayName: ""
 
 # Set this value to specify a ServiceAccount that is allowed to list namespaces.
 # Leave empty to use the ServiceAccount shipped with this chart.
-# If you use a custom ServiceAccount it must be able to list namespaces in your cluster.
+# If you use a custom ServiceAccount, it must be able to list namespaces in your cluster.
 customServiceAccountName: ""
 
 affinity: {}

--- a/chart/kubeseal-webgui/values.yaml
+++ b/chart/kubeseal-webgui/values.yaml
@@ -25,9 +25,10 @@ fullnameOverride: ""
 # Optionally setup a display name for your kubeseal-webgui instance.
 displayName: ""
 
-# Set this value to false if you already have a default serviceaccount who is allowed to list namespaces.
-serviceaccount:
-  create: true
+# Set this value to specify a ServiceAccount who is allowed to list namespaces.
+# Leave empty to use the ServiceAccount shipped with this chart.
+# If you use a custom ServiceAccount it must be able to list namespaces in your cluster.
+customServiceAccountName: ""
 
 affinity: {}
 
@@ -45,7 +46,6 @@ resources:
     memory: 256Mi
 
 # Setup an ingress route optionally
-
 ingress:
   enabled: false
   annotations: {}
@@ -61,6 +61,7 @@ route:
   enabled: false
   hostname: ""
   tls:
+    enabled: true
     termination: edge
     insecureEdgeTerminationPolicy: None
 


### PR DESCRIPTION
Add toggle for enable/disable TLS in OpenShift Route.
Add value to specify a custom service account. Otherwise the kubeseal-webgui service account will be used.

Fixes #241 