### PR TITLE
fix: hide info box when all required fields are filled

### DIFF
--- a/ui/src/components/Secrets.vue
+++ b/ui/src/components/Secrets.vue
@@ -495,7 +495,9 @@ const isEncryptButtonEnabled = computed(() => {
   return (
     secretName.value &&
     namespaceName.value &&
-    secrets.value.every(secret => secret.key && (secret.value || secret.file.length))
+    secrets.value.every(secret => secret.key && (
+      secret.value || secret.file instanceof Blob || secret.file instanceof File
+    ))
   );
 });
 


### PR DESCRIPTION
When a file was chosen instead of a text value, the info box was not hidden.