### PR TITLE
feat: differentiate between clean and edit when returning from sealed secrets

### DIFF
--- a/ui/src/components/Secrets.vue
+++ b/ui/src/components/Secrets.vue
@@ -310,10 +310,21 @@ spec:
             block
             variant="plain"
             class="flex-fill"
-            prepend-icon="mdi-autorenew"
+            prepend-icon="mdi-delete"
             @click="resetForm"
           >
-            Encrypt more secrets
+            Clear secrets
+          </v-btn>
+        </v-col>
+        <v-col class="d-flex">
+          <v-btn
+            block
+            variant="plain"
+            class="flex-fill"
+            prepend-icon="mdi-pencil"
+            @click="displayCreateSealedSecretForm=true"
+          >
+            Edit secrets
           </v-btn>
         </v-col>
       </v-row>


### PR DESCRIPTION
Add a new button to return from the sealed secrets view. Now we can choose, whether we want to clear the given secrets or edit them again.