### PR TITLE
fix: get sealed secret from correct element when filling the clipboard

### DIFF
--- a/ui/src/components/Secrets.vue
+++ b/ui/src/components/Secrets.vue
@@ -623,7 +623,7 @@ const renderSecrets = (sealedSecrets) => {
 }
 
 function copyRenderedSecrets() {
-  const sealedSecretContent = sealedSecret.value.innerText.trim();
+  const sealedSecretContent = sealedSecret.value.$el.innerText.trim()
   navigator.clipboard.writeText(sealedSecretContent);
 }
 


### PR DESCRIPTION
fixes #272