### PR TITLE
feat: multi-tenant and multi-namespace support

### DIFF
--- a/api/kubeseal_webgui_api/app.py
+++ b/api/kubeseal_webgui_api/app.py
@@ -4,10 +4,8 @@ import logging
 import fastapi
 from fastapi.middleware.cors import CORSMiddleware
 
-from .app_config import fetch_sealed_secrets_cert
+from .app_config import fetch_sealed_secrets_cert, settings, LOGGER
 from .routers import config, kubernetes, kubeseal
-
-LOGGER = logging.getLogger("kubeseal-webgui")
 
 
 @asynccontextmanager
@@ -23,6 +21,10 @@ app = fastapi.FastAPI(lifespan=lifespan)
 origins = [
     "http://localhost:8080",
 ]
+
+if settings.origin_url:
+    origins.append(settings.origin_url)
+LOGGER.info(origins)
 
 app.add_middleware(
     CORSMiddleware,

--- a/api/kubeseal_webgui_api/app_config.py
+++ b/api/kubeseal_webgui_api/app_config.py
@@ -8,6 +8,7 @@ binary = environ.get("KUBESEAL_BINARY", "/bin/false")
 mock = environ.get("MOCK_ENABLED", "False").lower() == "true"
 autofetch = environ.get("KUBESEAL_AUTOFETCH", "false")
 kubeseal_cert = environ.get("KUBESEAL_CERT", "/kubeseal-webgui/cert/kubeseal-cert.pem")
+origin_url = environ.get("ORIGIN_URL", "")
 
 
 class AppSettings(BaseSettings):
@@ -16,6 +17,7 @@ class AppSettings(BaseSettings):
     kubeseal_cert: str = environ.get("KUBESEAL_CERT", "/dev/null")
     mock_enabled: bool = mock
     mock_namespace_count: int = 120
+    origin_url: str = origin_url
 
 
 LOGGER = logging.getLogger("kubeseal-webgui")

--- a/chart/kubeseal-webgui/Chart.yaml
+++ b/chart/kubeseal-webgui/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: kubeseal-webgui
 description: A Helm chart for installing kubeseal-webgui
-version: 6.0.9
+version: 6.1.0
 appVersion: 4.8.1

--- a/chart/kubeseal-webgui/templates/configmap.yaml
+++ b/chart/kubeseal-webgui/templates/configmap.yaml
@@ -11,10 +11,12 @@ data:
 {{- toYaml .Values.sealedSecrets.cert | nindent 4 }}
 {{- end }}
   config.json: |-
-    { 
+    {
       "api_url": {{ .Values.api.url | quote }},
       "display_name": {{ .Values.displayName | quote }},
       "kubeseal_webgui_ui_version": {{ .Values.ui.image.tag | quote}},
       "kubeseal_webgui_api_version": {{ .Values.api.image.tag | quote}}
+      {{- if .Values.ui.environments }}
+      ,"environments": {{ .Values.ui.environments | toJson }}
+      {{- end }}
     }
-

--- a/chart/kubeseal-webgui/templates/deployment.yaml
+++ b/chart/kubeseal-webgui/templates/deployment.yaml
@@ -1,3 +1,6 @@
+{{- if and (not .Values.api.enabled) (not .Values.ui.enabled) -}}
+{{- fail "Invalid values: at least one of api.enabled or ui.enabled must be true." -}}
+{{- end -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/chart/kubeseal-webgui/templates/deployment.yaml
+++ b/chart/kubeseal-webgui/templates/deployment.yaml
@@ -34,6 +34,7 @@ spec:
       {{ toYaml .Values.nodeSelector | nindent 8 }}
       {{- end }}
       containers:
+        {{- if .Values.api.enabled }}
         - name: "api"
           image: "{{ .Values.api.image.repository }}:{{ .Values.api.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -43,7 +44,7 @@ spec:
               value: {{ $value | quote }}
           {{- end }}
             - name: ORIGIN_URL
-              value: "{{ .Values.api.url }}"
+              value: "{{ .Values.publicUrl }}"
             - name: KUBESEAL_CERT
               value: "/kubeseal-webgui/cert/kubeseal-cert.pem"
             {{- if .Values.sealedSecrets.autoFetchCert }}
@@ -84,6 +85,8 @@ spec:
             - name: sealed-secret-configmap
               mountPath: /kubeseal-webgui/src/config/logging_config.yaml
               subPath: logging_config.yaml
+        {{- end }}
+        {{- if .Values.ui.enabled }}
         - name: "ui"
           image: "{{ .Values.ui.image.repository }}:{{ .Values.ui.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -107,6 +110,7 @@ spec:
             - name: sealed-secret-configmap
               mountPath: /usr/share/nginx/html/config.json
               subPath: config.json
+        {{- end }}
       volumes:
         {{- if .Values.sealedSecrets.autoFetchCert }}
         - name: sealed-secrets-certs

--- a/chart/kubeseal-webgui/templates/ingress-api.yaml
+++ b/chart/kubeseal-webgui/templates/ingress-api.yaml
@@ -1,0 +1,36 @@
+{{- if and .Values.api.enabled .Values.api.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "kubeseal-webgui.fullname" . }}-api
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kubeseal-webgui.labels" . | nindent 4 }}
+  {{- if .Values.api.ingress.annotations }}
+  annotations:
+    {{- range $key, $value := .Values.api.ingress.annotations }}
+    {{ $key }}: {{ tpl $value $ | quote }}
+    {{- end }}
+  {{- end }}
+spec:
+{{- if .Values.api.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.api.ingress.ingressClassName }}
+{{- end }}
+{{- if .Values.api.ingress.tls.enabled }}
+  tls:
+  - hosts:
+    - {{ .Values.api.ingress.hostname }}
+    secretName: {{ .Values.api.ingress.tls.secretName }}
+{{- end }}
+  rules:
+  - host: {{ .Values.api.ingress.hostname }}
+    http:
+      paths:
+      - backend:
+          service:
+            name: {{ include "kubeseal-webgui.fullname" . }}-api
+            port:
+              number: 5000
+        path: /
+        pathType: Prefix
+{{- end }}

--- a/chart/kubeseal-webgui/templates/ingress.yaml
+++ b/chart/kubeseal-webgui/templates/ingress.yaml
@@ -1,4 +1,7 @@
-{{- $ingress := .Values.ui.ingress | default .Values.ingress -}}
+{{- $ingress := .Values.ingress -}}
+{{- if .Values.ui.ingress.enabled -}}
+{{- $ingress = .Values.ui.ingress -}}
+{{- end -}}
 {{- if $ingress.enabled -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress

--- a/chart/kubeseal-webgui/templates/ingress.yaml
+++ b/chart/kubeseal-webgui/templates/ingress.yaml
@@ -1,4 +1,5 @@
-{{- if .Values.ingress.enabled -}}
+{{- $ingress := .Values.ui.ingress | default .Values.ingress -}}
+{{- if $ingress.enabled -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -6,24 +7,24 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kubeseal-webgui.labels" . | nindent 4 }}
-  {{- if .Values.ingress.annotations }}
+  {{- if $ingress.annotations }}
   annotations:
-    {{- range $key, $value := .Values.ingress.annotations }}
+    {{- range $key, $value := $ingress.annotations }}
     {{ $key }}: {{ tpl $value $ | quote }}
     {{- end }}
   {{- end }}
 spec:
-{{- if .Values.ingress.ingressClassName }}
-  ingressClassName: {{ .Values.ingress.ingressClassName }}
+{{- if $ingress.ingressClassName }}
+  ingressClassName: {{ $ingress.ingressClassName }}
 {{- end }}
-{{- if .Values.ingress.tls.enabled }}
+{{- if $ingress.tls.enabled }}
   tls:
   - hosts:
-    - {{ .Values.ingress.hostname }}
-    secretName: {{ .Values.ingress.tls.secretName }}
+    - {{ $ingress.hostname }}
+    secretName: {{ $ingress.tls.secretName }}
 {{- end }}
   rules:
-  - host: {{ .Values.ingress.hostname }}
+  - host: {{ $ingress.hostname }}
     http:
       paths:
       - backend:

--- a/chart/kubeseal-webgui/templates/route-api.yaml
+++ b/chart/kubeseal-webgui/templates/route-api.yaml
@@ -1,0 +1,28 @@
+{{- if and .Values.api.enabled .Values.api.route.enabled -}}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ include "kubeseal-webgui.fullname" . }}-api
+  labels:
+    {{- include "kubeseal-webgui.labels" . | nindent 4 }}
+{{- with .Values.api.route.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- if .Values.api.route.hostname }}
+  host: {{ .Values.api.route.hostname | quote }}
+{{- end }}
+  to:
+    kind: Service
+    name: {{ include "kubeseal-webgui.fullname" . }}-api
+    weight: 100
+  port:
+    targetPort: api
+  {{- if .Values.api.route.tls.enabled }}
+  tls:
+    termination: {{ .Values.api.route.tls.termination }}
+    insecureEdgeTerminationPolicy: {{ .Values.api.route.tls.insecureEdgeTerminationPolicy }}
+  {{- end }}
+  wildcardPolicy: None
+{{- end }}

--- a/chart/kubeseal-webgui/templates/route-ui.yaml
+++ b/chart/kubeseal-webgui/templates/route-ui.yaml
@@ -1,18 +1,18 @@
-
-{{- if .Values.route.enabled -}}
+{{- $route := .Values.ui.route | default .Values.route -}}
+{{- if $route.enabled -}}
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   name: {{ include "kubeseal-webgui.fullname" . }}
   labels:
     {{- include "kubeseal-webgui.labels" . | nindent 4 }}
-{{- with .Values.route.annotations }}
+{{- with $route.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
-{{- if .Values.route.hostname }}
-  host: {{ .Values.route.hostname | quote }}
+{{- if $route.hostname }}
+  host: {{ $route.hostname | quote }}
 {{- end }}
   to:
     kind: Service
@@ -20,10 +20,10 @@ spec:
     weight: 100
   port:
     targetPort: ui
-  {{- if .Values.route.tls.enabled }}
+  {{- if $route.tls.enabled }}
   tls:
-    termination: {{ .Values.route.tls.termination }}
-    insecureEdgeTerminationPolicy: {{ .Values.route.tls.insecureEdgeTerminationPolicy }}
+    termination: {{ $route.tls.termination }}
+    insecureEdgeTerminationPolicy: {{ $route.tls.insecureEdgeTerminationPolicy }}
   {{- end }}
   wildcardPolicy: None
 {{- end }}

--- a/chart/kubeseal-webgui/templates/route-ui.yaml
+++ b/chart/kubeseal-webgui/templates/route-ui.yaml
@@ -1,4 +1,7 @@
-{{- $route := .Values.ui.route | default .Values.route -}}
+{{- $route := .Values.route -}}
+{{- if .Values.ui.route.enabled -}}
+{{- $route = .Values.ui.route -}}
+{{- end -}}
 {{- if $route.enabled -}}
 apiVersion: route.openshift.io/v1
 kind: Route

--- a/chart/kubeseal-webgui/templates/service-api.yaml
+++ b/chart/kubeseal-webgui/templates/service-api.yaml
@@ -1,8 +1,8 @@
-{{- if .Values.ui.enabled }}
+{{- if .Values.api.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "kubeseal-webgui.fullname" . }}
+  name: {{ include "kubeseal-webgui.fullname" . }}-api
   labels:
     {{- include "kubeseal-webgui.labels" . | nindent 4 }}
 spec:
@@ -10,8 +10,8 @@ spec:
     app: {{ template "kubeseal-webgui.name" . }}
   type: ClusterIP
   ports:
-    - port: 8080
-      targetPort: ui
+    - port: 5000
+      targetPort: api
       protocol: TCP
-      name: ui
+      name: api
 {{- end }}

--- a/chart/kubeseal-webgui/values.yaml
+++ b/chart/kubeseal-webgui/values.yaml
@@ -1,6 +1,10 @@
 replicaCount: 1
 annotations: {}
+# The public URL of the UI, used as CORS origin for the API.
+publicUrl: "http://localhost:8080"
 api:
+  # Enable or disable the API container (set to false for UI-only deployments)
+  enabled: true
   # The value of api.url should be set to the public-accessible http endpoint (ingress url or OpenShift route).
   # api.url will be generated into config.json ConfigMap of the UI. This statically served JSON file
   # is used by the UI to locate the API.
@@ -10,10 +14,50 @@ api:
     tag: 4.8.1
   environment: {}
   loglevel: "INFO"
+  ingress:
+    enabled: false
+    annotations: {}
+    ingressClassName: ""
+    hostname: "kubeseal-api.example.com"
+    tls:
+      enabled: false
+      secretName: ""
+  route:
+    enabled: false
+    hostname: ""
+    annotations: {}
+    tls:
+      enabled: true
+      termination: edge
+      insecureEdgeTerminationPolicy: None
 ui:
+  # Enable or disable the UI container (set to false for API-only deployments)
+  enabled: true
   image:
     repository: ghcr.io/jaydee94/kubeseal-webgui/ui
     tag: 4.8.1
+  # Map of environment names to API URLs for multi-tenant setups.
+  # Example:
+  #   environments:
+  #     cluster-a: https://kubeseal-api-a.example.com
+  #     cluster-b: https://kubeseal-api-b.example.com
+  environments: {}
+  ingress:
+    enabled: false
+    annotations: {}
+    ingressClassName: ""
+    hostname: "kubeseal-webgui.example.com"
+    tls:
+      enabled: false
+      secretName: ""
+  route:
+    enabled: false
+    hostname: ""
+    annotations: {}
+    tls:
+      enabled: true
+      termination: edge
+      insecureEdgeTerminationPolicy: None
 image:
   pullPolicy: Always
 nameOverride: ""
@@ -35,7 +79,8 @@ resources:
   requests:
     cpu: 20m
     memory: 256Mi
-# Setup an ingress route optionally
+# Legacy ingress configuration (for backward compatibility).
+# Prefer using ui.ingress and api.ingress for new deployments.
 ingress:
   enabled: false
   annotations: {}
@@ -44,8 +89,8 @@ ingress:
   tls:
     enabled: false
     secretName: ""
-# Optionally use a OpenShift-Route
-# If 'hostname' is an empty string (""), OpenShift will create a hostname for you.
+# Legacy route configuration (for backward compatibility).
+# Prefer using ui.route and api.route for new deployments.
 route:
   enabled: false
   hostname: ""

--- a/ui/public/config.json
+++ b/ui/public/config.json
@@ -1,5 +1,5 @@
 {
-  "api_url": "",
+  "api_url": "http://localhost:5000",
   "display_name": "Test",
   "kubeseal_webgui_ui_version": "2.1.0",
   "kubeseal_webgui_api_version": "2.1.0"

--- a/ui/src/components/SealedSecretCard.vue
+++ b/ui/src/components/SealedSecretCard.vue
@@ -32,7 +32,7 @@ spec:
         :icon="isCopied ? 'mdi-check' : 'mdi-content-copy'"
         size="small"
         class="copy-btn"
-        @click="$emit('copy')"
+        @click="copyToClipboard"
       >
         <v-icon>{{ isCopied ? 'mdi-check' : 'mdi-content-copy' }}</v-icon>
         <v-tooltip activator="parent" location="bottom">{{ isCopied ? 'Copied!' : 'Copy to clipboard' }}</v-tooltip>
@@ -71,9 +71,20 @@ defineProps({
   }
 })
 
-defineEmits(['copy'])
+const emit = defineEmits(['copy', 'copied'])
 
 const sealedSecretRef = ref(null)
+
+function copyToClipboard() {
+  if (sealedSecretRef.value) {
+    const content = sealedSecretRef.value.innerText.trim()
+    navigator.clipboard.writeText(content).then(() => {
+      emit('copied')
+    })
+  } else {
+    emit('copy')
+  }
+}
 
 // Expose ref for parent component to access
 defineExpose({ sealedSecretRef })

--- a/ui/src/components/SealedSecretCard.vue
+++ b/ui/src/components/SealedSecretCard.vue
@@ -75,13 +75,17 @@ const emit = defineEmits(['copy', 'copied'])
 
 const sealedSecretRef = ref(null)
 
-function copyToClipboard() {
-  if (sealedSecretRef.value) {
-    const content = sealedSecretRef.value.innerText.trim()
-    navigator.clipboard.writeText(content).then(() => {
-      emit('copied')
-    })
-  } else {
+async function copyToClipboard() {
+  if (!sealedSecretRef.value) {
+    emit('copy')
+    return
+  }
+
+  const content = sealedSecretRef.value.textContent?.trim() ?? ''
+  try {
+    await navigator.clipboard.writeText(content)
+    emit('copied')
+  } catch {
     emit('copy')
   }
 }

--- a/ui/src/components/SecretFormInputs.vue
+++ b/ui/src/components/SecretFormInputs.vue
@@ -41,6 +41,9 @@
           variant="outlined"
           class="modern-input"
           color="primary"
+          multiple
+          chips
+          closable-chips
           :disabled="['strict', 'namespace-wide'].indexOf(scope) === -1"
           @update:model-value="$emit('update:namespaceName', $event)"
         >
@@ -111,8 +114,8 @@ import { computed } from 'vue'
 
 const props = defineProps({
   namespaceName: {
-    type: String,
-    default: ''
+    type: Array,
+    default: () => []
   },
   secretName: {
     type: String,

--- a/ui/src/components/SecretFormInputs.vue
+++ b/ui/src/components/SecretFormInputs.vue
@@ -2,6 +2,31 @@
   <div>
     <v-row justify="end">
       <v-col
+        v-if="Object.keys(environments).length > 1"
+        cols="12"
+        md="3"
+      >
+        <v-select
+          :model-value="selectedEnvironment"
+          :items="Object.keys(environments)"
+          label="Environment"
+          variant="outlined"
+          class="modern-input"
+          color="primary"
+          prepend-inner-icon="mdi-server"
+          @update:model-value="$emit('update:selectedEnvironment', $event)"
+        >
+          <template #append-inner>
+            <v-tooltip location="bottom" max-width="300" open-on-click>
+              <template #activator="{ props: activatorProps }">
+                <v-icon v-bind="activatorProps" icon="mdi-information-outline" size="small" color="medium-emphasis" class="ml-2" />
+              </template>
+              <span>Select the target cluster environment.</span>
+            </v-tooltip>
+          </template>
+        </v-select>
+      </v-col>
+      <v-col
         cols="12"
         md="2"
       >
@@ -137,6 +162,14 @@ const props = defineProps({
     type: Object,
     required: true
   },
+  environments: {
+    type: Object,
+    default: () => ({})
+  },
+  selectedEnvironment: {
+    type: String,
+    default: ''
+  },
   secretNameError: {
     type: String,
     default: ''
@@ -147,7 +180,7 @@ const props = defineProps({
   }
 })
 
-defineEmits(['update:namespaceName', 'update:secretName', 'update:scope', 'toggle-favorite'])
+defineEmits(['update:namespaceName', 'update:secretName', 'update:scope', 'update:selectedEnvironment', 'toggle-favorite'])
 
 // Sort namespaces with favorites first
 const sortedNamespaces = computed(() => {

--- a/ui/src/components/Secrets.vue
+++ b/ui/src/components/Secrets.vue
@@ -23,7 +23,7 @@
       </div>
       <v-card
         v-else-if="displayCreateSealedSecretForm"
-        class="secrets-form modern-card pa-6 mb-6"
+        class="secrets-form modern-card pa-6 mb-6 mt-4"
         elevation="1"
         variant="outlined"
       >

--- a/ui/src/components/Secrets.vue
+++ b/ui/src/components/Secrets.vue
@@ -8,26 +8,6 @@
       {{ displayName }}
     </v-container>
 
-    <!-- Environment Selector -->
-    <v-row
-      v-if="Object.keys(environments).length > 1"
-      justify="center"
-      class="mb-4"
-    >
-      <v-col cols="12" sm="6" md="4">
-        <v-select
-          v-model="selectedEnvironment"
-          :items="Object.keys(environments)"
-          label="Environment"
-          variant="outlined"
-          class="modern-input"
-          color="primary"
-          density="comfortable"
-          prepend-inner-icon="mdi-server"
-        />
-      </v-col>
-    </v-row>
-
     <!-- Form and Results Section -->
     <transition name="fade" mode="out-in">
       <div
@@ -52,8 +32,10 @@
             v-model:namespace-name="namespaceName"
             v-model:secret-name="secretName"
             v-model:scope="scope"
+            v-model:selected-environment="selectedEnvironment"
             :namespaces="namespaces"
             :scopes="scopes"
+            :environments="environments"
             :rules="rules"
             :secret-name-error="secretNameError"
             :favorite-namespaces="favoriteNamespaces"

--- a/ui/src/components/Secrets.vue
+++ b/ui/src/components/Secrets.vue
@@ -8,6 +8,26 @@
       {{ displayName }}
     </v-container>
 
+    <!-- Environment Selector -->
+    <v-row
+      v-if="Object.keys(environments).length > 1"
+      justify="center"
+      class="mb-4"
+    >
+      <v-col cols="12" sm="6" md="4">
+        <v-select
+          v-model="selectedEnvironment"
+          :items="Object.keys(environments)"
+          label="Environment"
+          variant="outlined"
+          class="modern-input"
+          color="primary"
+          density="comfortable"
+          prepend-inner-icon="mdi-server"
+        />
+      </v-col>
+    </v-row>
+
     <!-- Form and Results Section -->
     <transition name="fade" mode="out-in">
       <div
@@ -129,7 +149,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onBeforeMount, onMounted } from 'vue'
+import { ref, computed, onBeforeMount, onMounted, watch } from 'vue'
 import SecretFormInputs from './SecretFormInputs.vue'
 import SecretsList from './SecretsList.vue'
 import SecretsResults from './SecretsResults.vue'
@@ -143,6 +163,7 @@ defineOptions({
 const { fetchConfig } = useConfig()
 const { fetchNamespaces, fetchEncodedSecrets: fetchEncodedSecretsApi } = useSecrets()
 
+let config = null
 
 const namespaces = ref([])
 const scopes = ref(["strict", "cluster-wide", "namespace-wide"])
@@ -152,7 +173,7 @@ const displayName = ref("")
 const displayCreateSealedSecretForm = ref(true)
 const loading = ref(false)
 const secretName = ref("")
-const namespaceName = ref("")
+const namespaceName = ref([])
 const scope = ref("strict")
 const secrets = ref([{ key: "", value: "", file: [] }])
 const sealedSecrets = ref([])
@@ -170,10 +191,30 @@ const secretNameError = computed(() => {
   return "";
 });
 
+// Multi-tenant environment state
+const environments = ref({})
+const selectedEnvironment = ref("")
+
+const selectedApiUrl = computed(() => {
+  return environments.value[selectedEnvironment.value] || ""
+})
+
+function fetchEnvironments(cfg) {
+  const envs = { default: cfg.api_url }
+  if (cfg.environments) {
+    Object.assign(envs, cfg.environments)
+  }
+  environments.value = envs
+}
+
+watch(selectedEnvironment, () => {
+  fetchNamespacesData()
+})
+
 const resetForm = () => {
   displayCreateSealedSecretForm.value = true;
   secretName.value = "";
-  namespaceName.value = "";
+  namespaceName.value = [];
   scope.value = "strict";
   secrets.value = [{ key: "", value: "", file: [] }];
   sealedSecrets.value = [];
@@ -182,8 +223,10 @@ const resetForm = () => {
 };
 
 onBeforeMount(async () => {
-  const config = await fetchConfig();
-  await fetchNamespacesData(config);
+  config = await fetchConfig();
+  fetchEnvironments(config);
+  selectedEnvironment.value = Object.keys(environments.value)[0];
+  await fetchNamespacesData();
   await fetchDisplayName(config);
 })
 
@@ -254,8 +297,8 @@ const incompleteSecretData = computed(() =>
 const notReadyToEncode = computed(() =>
   hasErrorMessage.value ||
   incompleteSecretData.value ||
-  (scope.value === "strict" && (namespaceName.value === "" || secretName.value === "")) ||
-  (scope.value === "namespace-wide" && namespaceName.value === "")
+  (scope.value === "strict" && (namespaceName.value.length === 0 || secretName.value === "")) ||
+  (scope.value === "namespace-wide" && namespaceName.value.length === 0)
 );
 
 const hasFile = computed(() =>
@@ -263,9 +306,18 @@ const hasFile = computed(() =>
 const hasValue = computed(() =>
   secrets.value.map((e) => e.value !== "")
 )
-const renderedSecrets = computed(() =>
-  renderSecrets(sealedSecrets.value)
-)
+
+const renderedSecrets = computed(() => {
+  if (Array.isArray(sealedSecrets.value) && sealedSecrets.value.length > 0 && sealedSecrets.value[0].namespace) {
+    // Multi-namespace results
+    return sealedSecrets.value.map(entry => ({
+      namespace: entry.namespace,
+      rendered: renderSecrets(entry.secrets)
+    }))
+  }
+  return renderSecrets(sealedSecrets.value)
+})
+
 const sealedSecretsAnnotations = computed(() => {
   if (scope.value === "strict") {
     return '{}';
@@ -289,17 +341,20 @@ function setErrorMessage(newErrorMessage) {
 const isEncryptButtonEnabled = computed(() => {
   return (
     secretName.value &&
-    namespaceName.value &&
+    namespaceName.value.length > 0 &&
     secrets.value.every(secret => secret.key && (
       secret.value || secret.file instanceof Blob || secret.file instanceof File
     ))
   );
 });
 
-async function fetchNamespacesData(config) {
+async function fetchNamespacesData() {
   try {
-    namespaces.value = await fetchNamespaces(config);
+    namespaces.value = [];
+    namespaceName.value = [];
+    namespaces.value = await fetchNamespaces(selectedApiUrl.value);
   } catch (error) {
+    namespaces.value = [];
     setErrorMessage(`Failed to fetch namespaces. Error Message: ${error.message}.`);
   }
 }
@@ -315,20 +370,41 @@ function toggleFavorite(namespace) {
   localStorage.favoriteNamespaces = JSON.stringify([...favoriteNamespaces.value]);
 }
 
-async function fetchDisplayName(config) {
-  displayName.value = config.display_name;
+async function fetchDisplayName(cfg) {
+  displayName.value = cfg.display_name;
 }
 
 async function fetchEncodedSecrets() {
   try {
     loading.value = true;
-    const config = await fetchConfig();
-    sealedSecrets.value = await fetchEncodedSecretsApi(config, {
-      secretName: secretName.value,
-      namespaceName: namespaceName.value,
-      scope: scope.value,
-      secrets: secrets.value
-    });
+    const apiUrl = selectedApiUrl.value;
+    const selectedNamespaces = namespaceName.value;
+
+    if (selectedNamespaces.length === 1) {
+      // Single namespace - keep backward-compatible response shape
+      const result = await fetchEncodedSecretsApi(apiUrl, {
+        secretName: secretName.value,
+        namespaceName: selectedNamespaces[0],
+        scope: scope.value,
+        secrets: secrets.value
+      });
+      sealedSecrets.value = result;
+    } else {
+      // Multiple namespaces - parallel API calls
+      const results = await Promise.all(
+        selectedNamespaces.map(async (ns) => {
+          const result = await fetchEncodedSecretsApi(apiUrl, {
+            secretName: secretName.value,
+            namespaceName: ns,
+            scope: scope.value,
+            secrets: secrets.value
+          });
+          return { namespace: ns, secrets: result };
+        })
+      );
+      sealedSecrets.value = results;
+    }
+
     // Add a small delay to make the transition noticeable and smooth
     await new Promise(resolve => setTimeout(resolve, 600));
     displayCreateSealedSecretForm.value = false;
@@ -340,40 +416,42 @@ async function fetchEncodedSecrets() {
   }
 }
 
-const renderSecrets = (sealedSecrets) => {
-  const dataEntries = sealedSecrets.map((element) =>
+const renderSecrets = (secrets) => {
+  const dataEntries = secrets.map((element) =>
     `    ${element["key"]}: ${element["value"]}`
   );
   return "\n" + dataEntries.join("\n");
 }
 
 function copyRenderedSecrets() {
-  // Access the nested ref through the SecretsResults component
-  const sealedSecretElement = secretsResultsRef.value?.sealedSecretCardRef?.$refs?.sealedSecretRef;
-  if (!sealedSecretElement) {
-    console.error('Could not access sealed secret element');
-    return;
-  }
-  const sealedSecretContent = sealedSecretElement.innerText.trim();
-  navigator.clipboard.writeText(sealedSecretContent).then(() => {
-    clipboardMessage.value = "Sealed secret copied to clipboard!";
-    clipboardSnackbar.value = true;
-    isCopiedMain.value = true;
-    setTimeout(() => {
-      isCopiedMain.value = false;
-    }, 2000);
-  });
+  // Called when the single-namespace SealedSecretCard has already copied its content
+  clipboardMessage.value = "Sealed secret copied to clipboard!";
+  clipboardSnackbar.value = true;
+  isCopiedMain.value = true;
+  setTimeout(() => {
+    isCopiedMain.value = false;
+  }, 2000);
 }
 
 function copySealedSecret(counter) {
-  navigator.clipboard.writeText(sealedSecrets.value[counter].value).then(() => {
-    clipboardMessage.value = `Secret key "${sealedSecrets.value[counter].key}" copied to clipboard!`;
+  // For multi-namespace, sealedSecrets is array of {namespace, secrets}
+  // For single namespace, sealedSecrets is flat array
+  const flatSecrets = getFlatSealedSecrets();
+  navigator.clipboard.writeText(flatSecrets[counter].value).then(() => {
+    clipboardMessage.value = `Secret key "${flatSecrets[counter].key}" copied to clipboard!`;
     clipboardSnackbar.value = true;
     copiedIndividual.value[counter] = true;
     setTimeout(() => {
       copiedIndividual.value[counter] = false;
     }, 2000);
   });
+}
+
+function getFlatSealedSecrets() {
+  if (Array.isArray(sealedSecrets.value) && sealedSecrets.value.length > 0 && sealedSecrets.value[0].namespace) {
+    return sealedSecrets.value.flatMap(entry => entry.secrets);
+  }
+  return sealedSecrets.value;
 }
 
 function removeSecret(counter) {

--- a/ui/src/components/SecretsResults.vue
+++ b/ui/src/components/SecretsResults.vue
@@ -1,26 +1,48 @@
 <template>
   <div>
-    <v-row>
-      <v-col>
-        <SealedSecretCard
-          ref="sealedSecretCardRef"
-          :secret-name="secretName"
-          :namespace-name="namespaceName"
-          :sealed-secrets-annotations="sealedSecretsAnnotations"
-          :rendered-secrets="renderedSecrets"
-          :is-copied="isCopiedMain"
-          :clipboard-available="clipboardAvailable"
-          @copy="$emit('copy-main')"
-        />
-      </v-col>
-    </v-row>
+    <!-- Multi-namespace results -->
+    <template v-if="isMultiNamespace">
+      <v-row v-for="(entry, idx) in renderedSecrets" :key="entry.namespace">
+        <v-col>
+          <SealedSecretCard
+            :ref="el => { if (el) sealedSecretCardRefs[idx] = el }"
+            :secret-name="secretName"
+            :namespace-name="entry.namespace"
+            :sealed-secrets-annotations="sealedSecretsAnnotations"
+            :rendered-secrets="entry.rendered"
+            :is-copied="copiedCards[idx] || false"
+            :clipboard-available="clipboardAvailable"
+            @copied="onCardCopied(idx)"
+          />
+        </v-col>
+      </v-row>
+    </template>
+
+    <!-- Single namespace result -->
+    <template v-else>
+      <v-row>
+        <v-col>
+          <SealedSecretCard
+            ref="sealedSecretCardRef"
+            :secret-name="secretName"
+            :namespace-name="singleNamespace"
+            :sealed-secrets-annotations="sealedSecretsAnnotations"
+            :rendered-secrets="renderedSecrets"
+            :is-copied="isCopiedMain"
+            :clipboard-available="clipboardAvailable"
+            @copied="$emit('copy-main')"
+          />
+        </v-col>
+      </v-row>
+    </template>
+
     <v-row
       dense
       align-content="center"
       class="mt-4"
     >
       <v-col
-        v-for="(secret, counter) in sealedSecrets"
+        v-for="(secret, counter) in flatSealedSecrets"
         :key="counter"
         cols="12"
         sm="6"
@@ -65,11 +87,11 @@
 </template>
 
 <script setup>
-import { ref } from 'vue'
+import { ref, computed } from 'vue'
 import SealedSecretCard from './SealedSecretCard.vue'
 import SecretKeyCard from './SecretKeyCard.vue'
 
-defineProps({
+const props = defineProps({
   sealedSecrets: {
     type: Array,
     required: true
@@ -79,15 +101,15 @@ defineProps({
     default: ''
   },
   namespaceName: {
-    type: String,
-    default: ''
+    type: Array,
+    default: () => []
   },
   sealedSecretsAnnotations: {
     type: String,
     required: true
   },
   renderedSecrets: {
-    type: String,
+    type: [String, Array],
     required: true
   },
   clipboardAvailable: {
@@ -107,7 +129,31 @@ defineProps({
 defineEmits(['copy-main', 'copy-individual', 'clear', 'edit'])
 
 const sealedSecretCardRef = ref(null)
+const sealedSecretCardRefs = ref([])
+const copiedCards = ref({})
 
-// Expose ref for parent component to access
-defineExpose({ sealedSecretCardRef })
+const isMultiNamespace = computed(() => {
+  return Array.isArray(props.renderedSecrets)
+})
+
+const singleNamespace = computed(() => {
+  return props.namespaceName.length > 0 ? props.namespaceName[0] : ''
+})
+
+const flatSealedSecrets = computed(() => {
+  if (Array.isArray(props.sealedSecrets) && props.sealedSecrets.length > 0 && props.sealedSecrets[0].namespace) {
+    return props.sealedSecrets.flatMap(entry => entry.secrets)
+  }
+  return props.sealedSecrets
+})
+
+function onCardCopied(idx) {
+  copiedCards.value[idx] = true
+  setTimeout(() => {
+    copiedCards.value[idx] = false
+  }, 2000)
+}
+
+// Expose refs for parent component to access
+defineExpose({ sealedSecretCardRef, sealedSecretCardRefs })
 </script>

--- a/ui/src/composables/useSecrets.js
+++ b/ui/src/composables/useSecrets.js
@@ -2,11 +2,11 @@ import { Base64 } from "js-base64";
 import { mockNamespacesResolver } from "@/utils/mockData";
 
 export function useSecrets() {
-  async function fetchNamespaces(config) {
+  async function fetchNamespaces(apiUrl) {
     if (import.meta.env.VITE_MOCK_NAMESPACES) {
       return mockNamespacesResolver(10);
     } else {
-      const response = await fetch(`${config.api_url}/namespaces`);
+      const response = await fetch(`${apiUrl}/namespaces`);
       if (!response.ok) {
           throw new Error(`Failed to fetch namespaces: ${response.statusText}`);
       }
@@ -25,7 +25,7 @@ export function useSecrets() {
     });
   }
 
-  async function fetchEncodedSecrets(config, { secretName, namespaceName, scope, secrets }) {
+  async function fetchEncodedSecrets(apiUrl, { secretName, namespaceName, scope, secrets }) {
     const requestObject = {
       secret: secretName,
       namespace: namespaceName,
@@ -52,7 +52,7 @@ export function useSecrets() {
 
     const requestBody = JSON.stringify(requestObject, null, "\t");
 
-    const response = await fetch(`${config.api_url}/secrets`, {
+    const response = await fetch(`${apiUrl}/secrets`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/ui/tests/test_ui.py
+++ b/ui/tests/test_ui.py
@@ -82,9 +82,9 @@ def namespace_select(page: Page):
     assert len(suggestions) > 0, "No suggestions found."
     first_suggestion_text = suggestions[0].inner_text()
     suggestions[0].click()
-    selected_text_selector = ".v-autocomplete__selection-text"
-    page.wait_for_selector(selected_text_selector, timeout=10000)
-    displayed_text = page.inner_text(selected_text_selector)
+    selected_chip_selector = ".v-autocomplete .v-chip__content"
+    page.wait_for_selector(selected_chip_selector, timeout=10000)
+    displayed_text = page.inner_text(selected_chip_selector)
     assert (
         displayed_text == first_suggestion_text
     ), f"Expected '{first_suggestion_text}', but got '{displayed_text}'"


### PR DESCRIPTION
## Summary

- **Multi-Tenant**: A single UI instance can connect to multiple API backends across different Kubernetes clusters via an environment selector dropdown
- **Multi-Namespace**: Users can select multiple namespaces and encrypt the same secret for all of them in one operation, producing separate sealed secret YAMLs per namespace
- **Helm Chart**: Independent API/UI deployment toggles, split ingress/route configurations, and environment injection via ConfigMap

## Changes

### API
- Add `ORIGIN_URL` environment variable for dynamic CORS origin, enabling cross-origin requests from a separately hosted UI

### Frontend
- Add environment selector dropdown (auto-hidden when only one environment configured)
- Refactor `useSecrets` composable to accept `apiUrl` string instead of config object
- Clear stale namespaces when switching environments or on fetch failure
- Enable multi-select namespace input with chips
- Make parallel API calls per selected namespace
- Render one SealedSecretCard per namespace with independent copy-to-clipboard

### Helm Chart
- Add `publicUrl` value for CORS origin configuration
- Add `api.enabled` / `ui.enabled` toggles for independent container deployment
- Add `ui.environments` map for multi-tenant API URL injection into config.json
- Split `ingress`/`route` into `api.ingress`/`ui.ingress` and `api.route`/`ui.route`
- Add dedicated `service-api`, `ingress-api`, and `route-api` templates
- Bump chart version to 6.1.0

## Deployment Examples

### Single cluster (backward compatible)
```bash
helm install kubeseal-webgui ./chart/kubeseal-webgui \
  --set publicUrl=https://kubeseal.example.com \
  --set ingress.enabled=true \
  --set ingress.hostname=kubeseal.example.com
```

### Multi-cluster: Cluster A (UI + API)
```yaml
publicUrl: "https://kubeseal-ui.example.com"
api:
  enabled: true
  url: "https://kubeseal-api-a.example.com"
  ingress:
    enabled: true
    hostname: "kubeseal-api-a.example.com"
ui:
  enabled: true
  environments:
    cluster-a: "https://kubeseal-api-a.example.com"
    cluster-b: "https://kubeseal-api-b.example.com"
  ingress:
    enabled: true
    hostname: "kubeseal-ui.example.com"
```

### Multi-cluster: Cluster B (API only)
```yaml
publicUrl: "https://kubeseal-ui.example.com"
api:
  enabled: true
  url: "https://kubeseal-api-b.example.com"
  ingress:
    enabled: true
    hostname: "kubeseal-api-b.example.com"
ui:
  enabled: false
```

## Test plan
- [ ] `helm template` with default values produces same resources as before
- [ ] `helm template` with `ui.enabled=false` omits UI service/container
- [ ] `helm template` with `api.enabled=false` + `ui.environments` set omits API resources, config.json includes environments
- [ ] Environment selector hidden with single environment, visible with multiple
- [ ] Multi-namespace select produces one sealed secret YAML per namespace
- [ ] Copy button on each card copies only that card's content
- [ ] CORS: remote API with `ORIGIN_URL` set accepts requests from UI origin

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-environment support with environment selector and per-environment API URLs
  * Multi-namespace selection with chip-style UI and multi-namespace results

* **Improvements**
  * Enhanced clipboard handling with explicit copy/copy-confirmation flows
  * Improved secret encryption flow handling for single vs. multiple namespaces
  * CORS origin handling extended via new public URL setting

* **Configuration**
  * Independent UI/API enablement and per-component ingress/route options

* **Version**
  * Helm chart version bumped to 6.1.0
<!-- end of auto-generated comment: release notes by coderabbit.ai -->