### PR TITLE
feat: add optional sealedsecret key import support

### DIFF
--- a/api/kubeseal_webgui_api/routers/kubernetes.py
+++ b/api/kubeseal_webgui_api/routers/kubernetes.py
@@ -8,14 +8,23 @@ from kubeseal_webgui_api.routers.kubernetes_namespace_resolver import (
     kubernetes_namespaces_resolver,
 )
 from kubeseal_webgui_api.routers.mock_namespace_resolver import mock_namespaces_resolver
+from kubeseal_webgui_api.routers.mock_sealed_secret_resolver import (
+    mock_sealed_secret_resolver,
+)
+from kubeseal_webgui_api.routers.models import ExistingSealedSecret
+from kubeseal_webgui_api.routers.kubernetes_sealed_secret_resolver import (
+    kubernetes_sealed_secret_resolver,
+)
 
 router = fastapi.APIRouter()
 LOGGER = logging.getLogger("kubeseal-webgui")
 
 if settings.mock_enabled:
     namespace_resolver = mock_namespaces_resolver
+    sealed_secret_resolver = mock_sealed_secret_resolver
 else:
     namespace_resolver = kubernetes_namespaces_resolver
+    sealed_secret_resolver = kubernetes_sealed_secret_resolver
 
 
 @router.get("/namespaces", response_model=List[str])
@@ -25,4 +34,14 @@ def get_namespaces() -> List[str]:
     except RuntimeError:
         raise fastapi.HTTPException(
             status_code=500, detail="Can't get namespaces from cluster."
+        )
+
+
+@router.get("/sealed-secrets/{namespace}", response_model=List[ExistingSealedSecret])
+def get_sealed_secrets(namespace: str) -> List[ExistingSealedSecret]:
+    try:
+        return sealed_secret_resolver(namespace)
+    except RuntimeError:
+        raise fastapi.HTTPException(
+            status_code=500, detail="Can't get SealedSecrets from cluster."
         )

--- a/api/kubeseal_webgui_api/routers/kubernetes_sealed_secret_resolver.py
+++ b/api/kubeseal_webgui_api/routers/kubernetes_sealed_secret_resolver.py
@@ -40,7 +40,7 @@ def kubernetes_sealed_secret_resolver(namespace: str) -> list[ExistingSealedSecr
         if not isinstance(name, str) or not isinstance(encrypted_data, dict):
             continue
 
-        keys = sorted(list(encrypted_data))
+        keys = sorted(encrypted_data)
         resolved_sealed_secrets.append(ExistingSealedSecret(name=name, keys=keys))
 
     return sorted(resolved_sealed_secrets, key=lambda sealed_secret: sealed_secret.name)

--- a/api/kubeseal_webgui_api/routers/kubernetes_sealed_secret_resolver.py
+++ b/api/kubeseal_webgui_api/routers/kubernetes_sealed_secret_resolver.py
@@ -40,7 +40,7 @@ def kubernetes_sealed_secret_resolver(namespace: str) -> list[ExistingSealedSecr
         if not isinstance(name, str) or not isinstance(encrypted_data, dict):
             continue
 
-        keys = sorted(encrypted_data)
+        keys = sorted(encrypted_data.keys())
         resolved_sealed_secrets.append(ExistingSealedSecret(name=name, keys=keys))
 
     return sorted(resolved_sealed_secrets, key=lambda sealed_secret: sealed_secret.name)

--- a/api/kubeseal_webgui_api/routers/kubernetes_sealed_secret_resolver.py
+++ b/api/kubeseal_webgui_api/routers/kubernetes_sealed_secret_resolver.py
@@ -23,7 +23,7 @@ def kubernetes_sealed_secret_resolver(namespace: str) -> list[ExistingSealedSecr
     resolved_sealed_secrets: list[ExistingSealedSecret] = []
     items = sealed_secret_list.get("items", [])
     if not isinstance(items, list):
-        LOGGER.warning("Unexpected SealedSecrets response payload: %s", sealed_secret_list)
+        LOGGER.warning("Unexpected SealedSecrets response payload type for namespace '%s'", namespace)
         return resolved_sealed_secrets
 
     for sealed_secret in items:

--- a/api/kubeseal_webgui_api/routers/kubernetes_sealed_secret_resolver.py
+++ b/api/kubeseal_webgui_api/routers/kubernetes_sealed_secret_resolver.py
@@ -40,7 +40,7 @@ def kubernetes_sealed_secret_resolver(namespace: str) -> list[ExistingSealedSecr
         if not isinstance(name, str) or not isinstance(encrypted_data, dict):
             continue
 
-        keys = sorted([key for key in encrypted_data if isinstance(key, str)])
+        keys = sorted(list(encrypted_data))
         resolved_sealed_secrets.append(ExistingSealedSecret(name=name, keys=keys))
 
     return sorted(resolved_sealed_secrets, key=lambda sealed_secret: sealed_secret.name)

--- a/api/kubeseal_webgui_api/routers/kubernetes_sealed_secret_resolver.py
+++ b/api/kubeseal_webgui_api/routers/kubernetes_sealed_secret_resolver.py
@@ -1,0 +1,46 @@
+import logging
+
+from kubernetes import client, config
+
+from kubeseal_webgui_api.routers.models import ExistingSealedSecret
+
+LOGGER = logging.getLogger("kubeseal-webgui")
+
+
+def kubernetes_sealed_secret_resolver(namespace: str) -> list[ExistingSealedSecret]:
+    """Retrieve SealedSecrets and their keys for a namespace from the cluster."""
+    config.load_incluster_config()
+    custom_objects_api = client.CustomObjectsApi()
+
+    LOGGER.info("Resolving in-cluster SealedSecrets for namespace '%s'", namespace)
+    sealed_secret_list = custom_objects_api.list_namespaced_custom_object(
+        group="bitnami.com",
+        version="v1alpha1",
+        namespace=namespace,
+        plural="sealedsecrets",
+    )
+
+    resolved_sealed_secrets: list[ExistingSealedSecret] = []
+    items = sealed_secret_list.get("items", [])
+    if not isinstance(items, list):
+        LOGGER.warning("Unexpected SealedSecrets response payload: %s", sealed_secret_list)
+        return resolved_sealed_secrets
+
+    for sealed_secret in items:
+        if not isinstance(sealed_secret, dict):
+            continue
+
+        metadata = sealed_secret.get("metadata", {})
+        spec = sealed_secret.get("spec", {})
+        if not isinstance(metadata, dict) or not isinstance(spec, dict):
+            continue
+
+        name = metadata.get("name")
+        encrypted_data = spec.get("encryptedData", {})
+        if not isinstance(name, str) or not isinstance(encrypted_data, dict):
+            continue
+
+        keys = sorted([key for key in encrypted_data if isinstance(key, str)])
+        resolved_sealed_secrets.append(ExistingSealedSecret(name=name, keys=keys))
+
+    return sorted(resolved_sealed_secrets, key=lambda sealed_secret: sealed_secret.name)

--- a/api/kubeseal_webgui_api/routers/kubernetes_sealed_secret_resolver.py
+++ b/api/kubeseal_webgui_api/routers/kubernetes_sealed_secret_resolver.py
@@ -23,7 +23,10 @@ def kubernetes_sealed_secret_resolver(namespace: str) -> list[ExistingSealedSecr
     resolved_sealed_secrets: list[ExistingSealedSecret] = []
     items = sealed_secret_list.get("items", [])
     if not isinstance(items, list):
-        LOGGER.warning("Unexpected SealedSecrets response payload type for namespace '%s'", namespace)
+        LOGGER.warning(
+            "Unexpected SealedSecrets response payload type for namespace '%s'",
+            namespace,
+        )
         return resolved_sealed_secrets
 
     for sealed_secret in items:

--- a/api/kubeseal_webgui_api/routers/mock_sealed_secret_resolver.py
+++ b/api/kubeseal_webgui_api/routers/mock_sealed_secret_resolver.py
@@ -1,0 +1,16 @@
+from typing import List
+
+from kubeseal_webgui_api.routers.models import ExistingSealedSecret
+
+
+def mock_sealed_secret_resolver(namespace: str) -> List[ExistingSealedSecret]:
+    return [
+        ExistingSealedSecret(
+            name=f"{namespace}-app-secrets",
+            keys=["API_KEY", "API_SECRET", "TOKEN"],
+        ),
+        ExistingSealedSecret(
+            name=f"{namespace}-db-secrets",
+            keys=["DATABASE", "HOST", "PASSWORD", "PORT", "USERNAME"],
+        ),
+    ]

--- a/api/kubeseal_webgui_api/routers/mock_sealed_secret_resolver.py
+++ b/api/kubeseal_webgui_api/routers/mock_sealed_secret_resolver.py
@@ -1,9 +1,7 @@
-from typing import List
-
 from kubeseal_webgui_api.routers.models import ExistingSealedSecret
 
 
-def mock_sealed_secret_resolver(namespace: str) -> List[ExistingSealedSecret]:
+def mock_sealed_secret_resolver(namespace: str) -> list[ExistingSealedSecret]:
     return [
         ExistingSealedSecret(
             name=f"{namespace}-app-secrets",

--- a/api/kubeseal_webgui_api/routers/models.py
+++ b/api/kubeseal_webgui_api/routers/models.py
@@ -19,6 +19,11 @@ class KeyValuePair(BaseModel):
     value: str
 
 
+class ExistingSealedSecret(BaseModel):
+    name: str
+    keys: List[str]
+
+
 class Secret(BaseModel):
     key: str
     value: Optional[str] = None

--- a/api/tests/test_kubernetes_service.py
+++ b/api/tests/test_kubernetes_service.py
@@ -4,6 +4,7 @@ from fastapi.testclient import TestClient
 
 from kubeseal_webgui_api.app import app
 from kubeseal_webgui_api.routers import kubernetes
+from kubeseal_webgui_api.routers.models import ExistingSealedSecret
 
 
 def dummy_namespace_resolver() -> List[str]:
@@ -12,6 +13,17 @@ def dummy_namespace_resolver() -> List[str]:
 
 def broken_namespace_resolver() -> List[str]:
     raise RuntimeError("Go away")
+
+
+def dummy_sealed_secret_resolver(namespace: str) -> List[ExistingSealedSecret]:
+    return [
+        ExistingSealedSecret(name=f"{namespace}-first", keys=["ALPHA", "BETA"]),
+        ExistingSealedSecret(name=f"{namespace}-second", keys=["DELTA"]),
+    ]
+
+
+def broken_sealed_secret_resolver(namespace: str) -> List[ExistingSealedSecret]:
+    raise RuntimeError(f"Go away from {namespace}")
 
 
 client = TestClient(app)
@@ -29,3 +41,18 @@ def test_get_namespaces():
     response = client.get("/namespaces")
     assert response.status_code == 200
     assert response.json() == dummy_namespace_resolver()
+
+
+def test_get_sealed_secrets_with_exception():
+    kubernetes.sealed_secret_resolver = broken_sealed_secret_resolver
+    response = client.get("/sealed-secrets/default")
+    assert response.status_code == 500
+    assert response.json() == {"detail": "Can't get SealedSecrets from cluster."}
+
+
+def test_get_sealed_secrets():
+    namespace = "default"
+    kubernetes.sealed_secret_resolver = dummy_sealed_secret_resolver
+    response = client.get(f"/sealed-secrets/{namespace}")
+    assert response.status_code == 200
+    assert response.json() == [item.model_dump() for item in dummy_sealed_secret_resolver(namespace)]

--- a/chart/kubeseal-webgui/templates/clusterrole.yaml
+++ b/chart/kubeseal-webgui/templates/clusterrole.yaml
@@ -13,5 +13,8 @@ rules:
 - apiGroups: [""]
   resources: ["namespaces"]
   verbs: ["list"]
+- apiGroups: ["bitnami.com"]
+  resources: ["sealedsecrets"]
+  verbs: ["get", "list"]
 {{- end }}
 

--- a/chart/kubeseal-webgui/templates/configmap.yaml
+++ b/chart/kubeseal-webgui/templates/configmap.yaml
@@ -14,7 +14,7 @@ data:
     { 
       "api_url": {{ .Values.api.url | quote }},
       "display_name": {{ .Values.displayName | quote }},
+      "enable_existing_sealed_secret_loading": {{ .Values.enableExistingSealedSecretLoading }},
       "kubeseal_webgui_ui_version": {{ .Values.ui.image.tag | quote}},
       "kubeseal_webgui_api_version": {{ .Values.api.image.tag | quote}}
     }
-

--- a/chart/kubeseal-webgui/values.yaml
+++ b/chart/kubeseal-webgui/values.yaml
@@ -20,6 +20,8 @@ nameOverride: ""
 fullnameOverride: ""
 # Optionally setup a display name for your kubeseal-webgui instance.
 displayName: ""
+# Optional feature flag to load existing SealedSecret keys from a namespace in the UI.
+enableExistingSealedSecretLoading: false
 # Set this value to specify a ServiceAccount that is allowed to list namespaces.
 # Leave empty to use the ServiceAccount shipped with this chart.
 # If you use a custom ServiceAccount, it must be able to list namespaces in your cluster.

--- a/ui/public/config.json
+++ b/ui/public/config.json
@@ -1,6 +1,7 @@
 {
   "api_url": "",
   "display_name": "Test",
+  "enable_existing_sealed_secret_loading": false,
   "kubeseal_webgui_ui_version": "2.1.0",
   "kubeseal_webgui_api_version": "2.1.0"
 }

--- a/ui/src/components/Secrets.vue
+++ b/ui/src/components/Secrets.vue
@@ -151,6 +151,21 @@
       />
     </transition>
 
+    <!-- Confirmation dialog for overwriting secret keys -->
+    <v-dialog v-model="confirmOverwriteDialog" max-width="440" persistent>
+      <v-card>
+        <v-card-title class="text-h6">Replace key list?</v-card-title>
+        <v-card-text>
+          This will replace the current key-value list with keys from the selected SealedSecret.
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn variant="text" @click="cancelOverwrite">Cancel</v-btn>
+          <v-btn color="primary" variant="elevated" @click="confirmOverwrite">Continue</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+
     <!-- Snackbars -->
     <v-snackbar
       v-model="showErrorSnackbar"
@@ -220,6 +235,8 @@ const sealedSecretImportEnabled = ref(false);
 const availableSealedSecrets = ref([]);
 const selectedSealedSecret = ref(null);
 const loadingSealedSecrets = ref(false);
+const confirmOverwriteDialog = ref(false);
+const pendingNewSealedSecret = ref(null);
 const secretNameError = computed(() => {
   if (!secretName.value) return "Secret name is required.";
   return "";
@@ -482,6 +499,8 @@ async function loadSealedSecretsForNamespace() {
 }
 
 watch([namespaceName, sealedSecretImportEnabled], async ([newNamespace, importEnabled]) => {
+  confirmOverwriteDialog.value = false;
+  pendingNewSealedSecret.value = null;
   if (!newNamespace || !importEnabled) {
     availableSealedSecrets.value = [];
     selectedSealedSecret.value = null;
@@ -495,21 +514,35 @@ watch(selectedSealedSecret, (newSealedSecret) => {
     return;
   }
   if (hasUserEnteredSecretData()) {
-    const continueOverwrite = window.confirm(
-      "This will replace the current key-value list with keys from the selected SealedSecret. Continue?"
-    );
-    if (!continueOverwrite) {
-      selectedSealedSecret.value = null;
-      return;
-    }
+    pendingNewSealedSecret.value = newSealedSecret;
+    confirmOverwriteDialog.value = true;
+    return;
   }
-  const secretEntries = newSealedSecret.keys.map((key) => ({ key, value: "", file: [] }));
-  secrets.value = secretEntries.length > 0 ? secretEntries : [{ key: "", value: "", file: [] }];
-  fileErrors.value = [];
+  applySelectedSealedSecret(newSealedSecret);
 });
 
+function applySelectedSealedSecret(sealedSecret) {
+  const secretEntries = sealedSecret.keys.map((key) => ({ key, value: "", file: [] }));
+  secrets.value = secretEntries.length > 0 ? secretEntries : [{ key: "", value: "", file: [] }];
+  fileErrors.value = [];
+}
+
+function confirmOverwrite() {
+  confirmOverwriteDialog.value = false;
+  if (pendingNewSealedSecret.value) {
+    applySelectedSealedSecret(pendingNewSealedSecret.value);
+    pendingNewSealedSecret.value = null;
+  }
+}
+
+function cancelOverwrite() {
+  confirmOverwriteDialog.value = false;
+  pendingNewSealedSecret.value = null;
+  selectedSealedSecret.value = null;
+}
+
 async function getConfig() {
-  if (!config.value.api_url) {
+  if (!Object.keys(config.value).length) {
     config.value = await fetchConfig();
   }
   return config.value;

--- a/ui/src/components/Secrets.vue
+++ b/ui/src/components/Secrets.vue
@@ -503,8 +503,8 @@ watch(selectedSealedSecret, (newSealedSecret) => {
       return;
     }
   }
-  const mappedSecrets = newSealedSecret.keys.map((key) => ({ key, value: "", file: [] }));
-  secrets.value = mappedSecrets.length > 0 ? mappedSecrets : [{ key: "", value: "", file: [] }];
+  const secretEntries = newSealedSecret.keys.map((key) => ({ key, value: "", file: [] }));
+  secrets.value = secretEntries.length > 0 ? secretEntries : [{ key: "", value: "", file: [] }];
   fileErrors.value = [];
 });
 
@@ -519,6 +519,7 @@ function hasUserEnteredSecretData() {
   return secrets.value.some((entry) =>
     entry.key !== "" ||
     entry.value !== "" ||
+    (Array.isArray(entry.file) && entry.file.length > 0) ||
     entry.file instanceof Blob ||
     entry.file instanceof File
   );

--- a/ui/src/components/Secrets.vue
+++ b/ui/src/components/Secrets.vue
@@ -40,6 +40,51 @@
             @toggle-favorite="toggleFavorite"
           />
 
+          <v-card
+            v-if="sealedSecretImportFeatureEnabled"
+            class="mb-6"
+            variant="tonal"
+          >
+            <v-card-text>
+              <v-switch
+                v-model="sealedSecretImportEnabled"
+                color="primary"
+                hide-details
+                label="Load keys from existing SealedSecret"
+              />
+              <v-row v-if="sealedSecretImportEnabled" class="mt-1">
+                <v-col cols="12" md="8">
+                  <v-autocomplete
+                    :model-value="selectedSealedSecret"
+                    :items="availableSealedSecrets"
+                    item-title="name"
+                    return-object
+                    label="Existing SealedSecret"
+                    variant="outlined"
+                    class="modern-input"
+                    color="primary"
+                    no-data-text="No SealedSecrets found for this namespace"
+                    :loading="loadingSealedSecrets"
+                    :disabled="!namespaceName || loadingSealedSecrets"
+                    @update:model-value="selectedSealedSecret = $event"
+                  />
+                </v-col>
+                <v-col cols="12" md="4" class="d-flex align-center">
+                  <v-btn
+                    block
+                    prepend-icon="mdi-refresh"
+                    variant="outlined"
+                    color="primary"
+                    :disabled="!namespaceName || loadingSealedSecrets"
+                    @click="loadSealedSecretsForNamespace()"
+                  >
+                    Refresh
+                  </v-btn>
+                </v-col>
+              </v-row>
+            </v-card-text>
+          </v-card>
+
           <SecretsList
             :secrets="secrets"
             :has-value="hasValue"
@@ -129,7 +174,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onBeforeMount, onMounted } from 'vue'
+import { ref, computed, onBeforeMount, onMounted, watch } from 'vue'
 import SecretFormInputs from './SecretFormInputs.vue'
 import SecretsList from './SecretsList.vue'
 import SecretsResults from './SecretsResults.vue'
@@ -141,9 +186,14 @@ defineOptions({
 })
 
 const { fetchConfig } = useConfig()
-const { fetchNamespaces, fetchEncodedSecrets: fetchEncodedSecretsApi } = useSecrets()
+const {
+  fetchNamespaces,
+  fetchSealedSecrets,
+  fetchEncodedSecrets: fetchEncodedSecretsApi
+} = useSecrets()
 
 
+const config = ref({})
 const namespaces = ref([])
 const scopes = ref(["strict", "cluster-wide", "namespace-wide"])
 const errorMessage = ref("")
@@ -165,6 +215,11 @@ const clipboardMessage = ref("");
 const isCopiedMain = ref(false);
 const copiedIndividual = ref({});
 const fileErrors = ref([]);
+const sealedSecretImportFeatureEnabled = ref(false);
+const sealedSecretImportEnabled = ref(false);
+const availableSealedSecrets = ref([]);
+const selectedSealedSecret = ref(null);
+const loadingSealedSecrets = ref(false);
 const secretNameError = computed(() => {
   if (!secretName.value) return "Secret name is required.";
   return "";
@@ -177,14 +232,18 @@ const resetForm = () => {
   scope.value = "strict";
   secrets.value = [{ key: "", value: "", file: [] }];
   sealedSecrets.value = [];
+  resetSealedSecretImport();
   hasErrorMessage.value = false;
   errorMessage.value = "";
 };
 
 onBeforeMount(async () => {
-  const config = await fetchConfig();
-  await fetchNamespacesData(config);
-  await fetchDisplayName(config);
+  config.value = await fetchConfig();
+  sealedSecretImportFeatureEnabled.value = isEnabled(
+    config.value.enable_existing_sealed_secret_loading
+  );
+  await fetchNamespacesData(config.value);
+  await fetchDisplayName(config.value);
 })
 
 onMounted(() => {
@@ -200,6 +259,16 @@ function readFavoriteNamespaces() {
   } catch {
     return new Set([]);
   }
+}
+
+function isEnabled(value) {
+  if (typeof value === "boolean") {
+    return value;
+  }
+  if (typeof value === "string") {
+    return ["true", "1", "yes", "on"].includes(value.toLowerCase());
+  }
+  return false;
 }
 
 function validDnsSubdomain(name) {
@@ -322,8 +391,10 @@ async function fetchDisplayName(config) {
 async function fetchEncodedSecrets() {
   try {
     loading.value = true;
-    const config = await fetchConfig();
-    sealedSecrets.value = await fetchEncodedSecretsApi(config, {
+    if (!config.value.api_url) {
+      config.value = await fetchConfig();
+    }
+    sealedSecrets.value = await fetchEncodedSecretsApi(config.value, {
       secretName: secretName.value,
       namespaceName: namespaceName.value,
       scope: scope.value,
@@ -387,6 +458,52 @@ function removeSecret(counter) {
 function removeAllSecrets() {
   secrets.value = [{ key: "", value: "", file: [] }];
 }
+
+function resetSealedSecretImport() {
+  sealedSecretImportEnabled.value = false;
+  availableSealedSecrets.value = [];
+  selectedSealedSecret.value = null;
+}
+
+async function loadSealedSecretsForNamespace() {
+  if (!namespaceName.value || !sealedSecretImportFeatureEnabled.value || !sealedSecretImportEnabled.value) {
+    availableSealedSecrets.value = [];
+    selectedSealedSecret.value = null;
+    return;
+  }
+
+  try {
+    loadingSealedSecrets.value = true;
+    if (!config.value.api_url) {
+      config.value = await fetchConfig();
+    }
+    availableSealedSecrets.value = await fetchSealedSecrets(config.value, namespaceName.value);
+  } catch (error) {
+    setErrorMessage(`Failed to fetch existing SealedSecrets. Error Message: ${error.message}.`);
+    availableSealedSecrets.value = [];
+    selectedSealedSecret.value = null;
+  } finally {
+    loadingSealedSecrets.value = false;
+  }
+}
+
+watch([namespaceName, sealedSecretImportEnabled], async ([newNamespace, importEnabled]) => {
+  if (!newNamespace || !importEnabled) {
+    availableSealedSecrets.value = [];
+    selectedSealedSecret.value = null;
+    return;
+  }
+  await loadSealedSecretsForNamespace();
+});
+
+watch(selectedSealedSecret, (newSealedSecret) => {
+  if (!newSealedSecret || !Array.isArray(newSealedSecret.keys)) {
+    return;
+  }
+  const mappedSecrets = newSealedSecret.keys.map((key) => ({ key, value: "", file: [] }));
+  secrets.value = mappedSecrets.length > 0 ? mappedSecrets : [{ key: "", value: "", file: [] }];
+  fileErrors.value = [];
+});
 
 function validateFile(file, counter) {
   const fileSizeRule = rules.fileSize[0];

--- a/ui/src/components/Secrets.vue
+++ b/ui/src/components/Secrets.vue
@@ -391,10 +391,7 @@ async function fetchDisplayName(config) {
 async function fetchEncodedSecrets() {
   try {
     loading.value = true;
-    if (!config.value.api_url) {
-      config.value = await fetchConfig();
-    }
-    sealedSecrets.value = await fetchEncodedSecretsApi(config.value, {
+    sealedSecrets.value = await fetchEncodedSecretsApi(await getConfig(), {
       secretName: secretName.value,
       namespaceName: namespaceName.value,
       scope: scope.value,
@@ -474,10 +471,7 @@ async function loadSealedSecretsForNamespace() {
 
   try {
     loadingSealedSecrets.value = true;
-    if (!config.value.api_url) {
-      config.value = await fetchConfig();
-    }
-    availableSealedSecrets.value = await fetchSealedSecrets(config.value, namespaceName.value);
+    availableSealedSecrets.value = await fetchSealedSecrets(await getConfig(), namespaceName.value);
   } catch (error) {
     setErrorMessage(`Failed to fetch existing SealedSecrets. Error Message: ${error.message}.`);
     availableSealedSecrets.value = [];
@@ -500,10 +494,35 @@ watch(selectedSealedSecret, (newSealedSecret) => {
   if (!newSealedSecret || !Array.isArray(newSealedSecret.keys)) {
     return;
   }
+  if (hasUserEnteredSecretData()) {
+    const continueOverwrite = window.confirm(
+      "This will replace the current key-value list with keys from the selected SealedSecret. Continue?"
+    );
+    if (!continueOverwrite) {
+      selectedSealedSecret.value = null;
+      return;
+    }
+  }
   const mappedSecrets = newSealedSecret.keys.map((key) => ({ key, value: "", file: [] }));
   secrets.value = mappedSecrets.length > 0 ? mappedSecrets : [{ key: "", value: "", file: [] }];
   fileErrors.value = [];
 });
+
+async function getConfig() {
+  if (!config.value.api_url) {
+    config.value = await fetchConfig();
+  }
+  return config.value;
+}
+
+function hasUserEnteredSecretData() {
+  return secrets.value.some((entry) =>
+    entry.key !== "" ||
+    entry.value !== "" ||
+    entry.file instanceof Blob ||
+    entry.file instanceof File
+  );
+}
 
 function validateFile(file, counter) {
   const fileSizeRule = rules.fileSize[0];

--- a/ui/src/composables/useSecrets.js
+++ b/ui/src/composables/useSecrets.js
@@ -15,7 +15,7 @@ export function useSecrets() {
   }
 
   async function fetchSealedSecrets(config, namespaceName) {
-    const response = await fetch(`${config.api_url}/sealed-secrets/${namespaceName}`);
+    const response = await fetch(`${config.api_url}/sealed-secrets/${encodeURIComponent(namespaceName)}`);
     if (!response.ok) {
       throw new Error(`Failed to fetch SealedSecrets: ${response.statusText}`);
     }

--- a/ui/src/composables/useSecrets.js
+++ b/ui/src/composables/useSecrets.js
@@ -14,6 +14,14 @@ export function useSecrets() {
     }
   }
 
+  async function fetchSealedSecrets(config, namespaceName) {
+    const response = await fetch(`${config.api_url}/sealed-secrets/${namespaceName}`);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch SealedSecrets: ${response.statusText}`);
+    }
+    return await response.json();
+  }
+
   function readFileAsync(file) {
     return new Promise((resolve, reject) => {
       let reader = new FileReader();
@@ -72,6 +80,7 @@ export function useSecrets() {
 
   return {
     fetchNamespaces,
+    fetchSealedSecrets,
     fetchEncodedSecrets
   };
 }


### PR DESCRIPTION
Agent-Logs-Url: https://github.com/Jaydee94/kubeseal-webgui/sessions/89f2a11d-9f25-4093-9cb8-6ce55917a43c

Co-authored-by: Jaydee94 <55805868+Jaydee94@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added API endpoint to retrieve existing sealed secrets from Kubernetes namespaces
  * Added UI feature to load and auto-populate secret keys from existing sealed secrets
  * Introduced confirmation dialog when loading secrets over user-entered data
  * Added feature flag to enable/disable sealed secret loading functionality

* **Tests**
  * Added test coverage for sealed secrets endpoint and error handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Jaydee94/kubeseal-webgui/pull/304?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->