### PR TITLE
feat: add optional imagePullSecrets support to helm chart

### DIFF
--- a/chart/kubeseal-webgui/Chart.yaml
+++ b/chart/kubeseal-webgui/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: kubeseal-webgui
 description: A Helm chart for installing kubeseal-webgui
-version: 6.0.11
+version: 6.0.12
 appVersion: 4.9.1

--- a/chart/kubeseal-webgui/README.md
+++ b/chart/kubeseal-webgui/README.md
@@ -43,6 +43,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `ui.image.repository`                     | Image-Repository and name of the ui image.        | `ghcr.io/jaydee94/kubeseal-webgui/ui`  |
 | `ui.image.tag`                            | Image Tag of the ui image.                        | `4.5.4`                                |
 | `image.pullPolicy`                        | Image Pull Policy                                 | `Always`                               |
+| `imagePullSecrets`                        | Image pull secrets for private registries.        | `[]`                                   |
 | `nameOverride`                            | Name-Override for the objects                     | `""`                                   |
 | `fullnameOverride`                        | Fullname-Override for the objects                 | `""`                                   |
 | `customServiceAccountName`                | Optionallyn define your own serviceaccount to use | `true`                                 |

--- a/chart/kubeseal-webgui/templates/deployment.yaml
+++ b/chart/kubeseal-webgui/templates/deployment.yaml
@@ -21,6 +21,10 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ .Values.customServiceAccountName | default "kubeseal-webgui" | quote }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if .Values.tolerations }}
       tolerations:
       {{ toYaml .Values.tolerations | nindent 8 }}

--- a/chart/kubeseal-webgui/values.yaml
+++ b/chart/kubeseal-webgui/values.yaml
@@ -16,6 +16,11 @@ ui:
     tag: 4.9.1
 image:
   pullPolicy: Always
+# Optionally provide image pull secrets for private registries.
+# Example:
+# imagePullSecrets:
+#   - name: my-registry-secret
+imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 # Optionally setup a display name for your kubeseal-webgui instance.


### PR DESCRIPTION
## Summary
Adds optional `imagePullSecrets` support to the Helm chart so the deployment can pull the API and UI container images from private registries or from dockerhub avoids throttling.

## Changes
- New `imagePullSecrets` value in `values.yaml`
- Conditional `imagePullSecrets` block in `templates/deployment.yaml`

## Usage
```yaml
imagePullSecrets:
  - name: my-registry-secret


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added image pull secrets support to the kubeseal-webgui Helm chart to allow pulling images from private registries.

* **Documentation**
  * Chart docs updated with the new imagePullSecrets parameter, example usage, and default value (empty list).

* **Chores**
  * Chart version bumped to include the above changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Jaydee94/kubeseal-webgui/pull/306?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->