### PR TITLE
ci: stabilize e2e test wait step

### DIFF
--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -27,11 +27,12 @@ jobs:
         run: |
           cd api
           pip install .
+          pip install pytest-rerunfailures
 
       - name: Install Playwright Browsers
         run: |
           cd api
-          playwright install
+          playwright install --with-deps chromium
       
       - name: Start Vue.js Development Server
         run: |
@@ -57,7 +58,7 @@ jobs:
       - name: Run Playwright Tests
         run: |
           cd ui
-          pytest tests/ -v
+          pytest tests/ -v --reruns 2 --reruns-delay 3
 
       - name: Upload dev-server log on failure
         if: failure()

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -36,15 +36,33 @@ jobs:
       - name: Start Vue.js Development Server
         run: |
           cd ui
-          npm install
-          nohup npm run dev &
+          npm ci --legacy-peer-deps
+          nohup npm run dev > dev-server.log 2>&1 &
           echo "Waiting for dev server on port 8080..."
-          for i in $(seq 1 30); do
-            curl -sf http://localhost:8080 > /dev/null 2>&1 && echo "Server ready after ${i}s" && break
+          ready=0
+          for i in $(seq 1 60); do
+            if curl -sf http://localhost:8080 > /dev/null 2>&1; then
+              echo "Server ready after ${i}s"
+              ready=1
+              break
+            fi
             sleep 1
           done
+          if [ "$ready" -ne 1 ]; then
+            echo "Dev server failed to start within 60s. Log output:"
+            cat dev-server.log || true
+            exit 1
+          fi
 
       - name: Run Playwright Tests
         run: |
           cd ui
-          pytest tests/
+          pytest tests/ -v
+
+      - name: Upload dev-server log on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ui-dev-server-log
+          path: ui/dev-server.log
+          if-no-files-found: ignore

--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -99,33 +99,51 @@ jobs:
         run: |
           set +e
           HOST=$(hostname -f)
-          echo "=== resolved host: ${HOST} ==="
-          echo "=== pods (kubeseal-webgui) ==="
-          kubectl get pods --namespace kubeseal-webgui -o wide
-          echo "=== describe deployment ==="
-          kubectl describe deployment --namespace kubeseal-webgui e2e-test-kubeseal-webgui
-          echo "=== describe pods ==="
-          kubectl describe pods --namespace kubeseal-webgui -l app=kubeseal-webgui
-          echo "=== api logs (current) ==="
-          kubectl logs --namespace kubeseal-webgui -l app=kubeseal-webgui -c api --tail=300
-          echo "=== api logs (previous) ==="
-          kubectl logs --namespace kubeseal-webgui -l app=kubeseal-webgui -c api --tail=300 -p
-          echo "=== ui logs (current) ==="
-          kubectl logs --namespace kubeseal-webgui -l app=kubeseal-webgui -c ui --tail=300
-          echo "=== events (kubeseal-webgui ns) ==="
-          kubectl get events --namespace kubeseal-webgui --sort-by=.lastTimestamp
-          echo "=== ingress ==="
-          kubectl get ingress --namespace kubeseal-webgui -o yaml
-          echo "=== services ==="
-          kubectl get svc --namespace kubeseal-webgui
-          echo "=== ingress-nginx pods ==="
-          kubectl get pods --namespace ingress-nginx -o wide
-          echo "=== ingress-nginx controller logs ==="
-          kubectl logs --namespace ingress-nginx -l app.kubernetes.io/component=controller --tail=200
-          echo "=== sealed-secrets pods ==="
-          kubectl get pods --namespace kube-system -l app.kubernetes.io/name=sealed-secrets -o wide
-          echo "=== direct curl to ingress ==="
-          curl -v "http://${HOST}:80/namespaces" || true
+          OUT=e2e-debug.log
+          {
+            echo "=== resolved host: ${HOST} ==="
+            echo "=== pods (kubeseal-webgui) ==="
+            kubectl get pods --namespace kubeseal-webgui -o wide
+            echo "=== describe deployment ==="
+            kubectl describe deployment --namespace kubeseal-webgui e2e-test-kubeseal-webgui
+            echo "=== describe pods ==="
+            kubectl describe pods --namespace kubeseal-webgui -l app=kubeseal-webgui
+            echo "=== api logs (current) ==="
+            kubectl logs --namespace kubeseal-webgui -l app=kubeseal-webgui -c api --tail=300
+            echo "=== api logs (previous) ==="
+            kubectl logs --namespace kubeseal-webgui -l app=kubeseal-webgui -c api --tail=300 -p
+            echo "=== ui logs (current) ==="
+            kubectl logs --namespace kubeseal-webgui -l app=kubeseal-webgui -c ui --tail=300
+            echo "=== events (kubeseal-webgui ns) ==="
+            kubectl get events --namespace kubeseal-webgui --sort-by=.lastTimestamp
+            echo "=== ingress ==="
+            kubectl get ingress --namespace kubeseal-webgui -o yaml
+            echo "=== services ==="
+            kubectl get svc --namespace kubeseal-webgui
+            echo "=== ingress-nginx pods ==="
+            kubectl get pods --namespace ingress-nginx -o wide
+            echo "=== ingress-nginx controller logs ==="
+            kubectl logs --namespace ingress-nginx -l app.kubernetes.io/component=controller --tail=200
+            echo "=== sealed-secrets pods ==="
+            kubectl get pods --namespace kube-system -l app.kubernetes.io/name=sealed-secrets -o wide
+            echo "=== direct curl to ingress ==="
+            curl -v "http://${HOST}:80/namespaces"
+          } 2>&1 | tee "$OUT"
+          {
+            echo '<details><summary>e2e debug output</summary>'
+            echo ''
+            echo '```'
+            cat "$OUT"
+            echo '```'
+            echo '</details>'
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload e2e debug log
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-debug-log
+          path: e2e-debug.log
+          if-no-files-found: ignore
       - name: Call URL
         run: |
           curl -f http://$(hostname -f):80/namespaces

--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -13,6 +13,10 @@ on:
 
 jobs:
   create-cluster:
+    permissions:
+      contents: read
+      pull-requests: write
+      actions: read
     runs-on: ubuntu-latest
     steps:
       - name: checkout
@@ -144,6 +148,30 @@ jobs:
           name: e2e-debug-log
           path: e2e-debug.log
           if-no-files-found: ignore
+      - name: Post debug log as PR comment
+        if: failure() && github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            let body;
+            try {
+              const log = fs.readFileSync('e2e-debug.log', 'utf8');
+              // GitHub comments cap at 65536 chars; keep ample headroom
+              const max = 60000;
+              const trimmed = log.length > max ? log.slice(-max) : log;
+              body = '### e2e create-cluster debug output (commit `'
+                + context.sha.substring(0, 7) + '`)\n\n```\n'
+                + trimmed + '\n```';
+            } catch (e) {
+              body = '### e2e create-cluster debug output\n\n_no debug file produced: ' + e.message + '_';
+            }
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body,
+            });
       - name: Call URL
         run: |
           curl -f http://$(hostname -f):80/namespaces

--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -130,6 +130,46 @@ jobs:
             kubectl logs --namespace ingress-nginx -l app.kubernetes.io/component=controller --tail=200
             echo "=== sealed-secrets pods ==="
             kubectl get pods --namespace kube-system -l app.kubernetes.io/name=sealed-secrets -o wide
+            echo "=== service account ==="
+            kubectl get serviceaccount --namespace kubeseal-webgui kubeseal-webgui -o yaml
+            echo "=== clusterrole ==="
+            kubectl get clusterrole kubeseal-webgui-list-namespaces -o yaml
+            echo "=== clusterrolebinding ==="
+            kubectl get clusterrolebinding kubeseal-webgui-list-namespaces -o yaml
+            echo "=== in-pod token / sa env / auth check ==="
+            POD=$(kubectl get pod --namespace kubeseal-webgui -l app=kubeseal-webgui -o jsonpath='{.items[0].metadata.name}')
+            kubectl exec --namespace kubeseal-webgui -c api "$POD" -- sh -c '
+              echo "--- KUBERNETES_* env ---"
+              env | grep ^KUBERNETES_ || true
+              echo "--- token file ---"
+              ls -la /var/run/secrets/kubernetes.io/serviceaccount/ 2>&1
+              wc -c /var/run/secrets/kubernetes.io/serviceaccount/token 2>&1
+              echo "--- token (first 20 chars) ---"
+              head -c 20 /var/run/secrets/kubernetes.io/serviceaccount/token 2>&1; echo
+              echo "--- curl k8s api with token ---"
+              TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+              curl -k -sS -o /tmp/resp -w "HTTP %{http_code}\n" \
+                -H "Authorization: Bearer ${TOKEN}" \
+                "https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}/api/v1/namespaces"
+              head -c 500 /tmp/resp; echo
+              echo "--- python load_incluster_config ---"
+              python3 -c "
+from kubernetes import client, config
+config.load_incluster_config()
+cfg = client.Configuration.get_default_copy()
+print(\"host=\", cfg.host)
+print(\"verify_ssl=\", cfg.verify_ssl)
+print(\"ssl_ca_cert=\", cfg.ssl_ca_cert)
+print(\"api_key present:\", bool(cfg.api_key))
+print(\"api_key authorization startswith bearer:\", str(cfg.api_key.get(\"authorization\",\"\"))[:20] if cfg.api_key else None)
+v1 = client.CoreV1Api()
+try:
+    ns = v1.list_namespace()
+    print(\"OK\", len(ns.items))
+except Exception as e:
+    print(\"ERR\", repr(e)[:300])
+"
+            ' 2>&1 || true
             echo "=== direct curl to ingress ==="
             curl -v "http://${HOST}:80/namespaces"
           } 2>&1 | tee "$OUT"

--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -71,29 +71,61 @@ jobs:
           kubectl rollout status --namespace kubeseal-webgui \
             deployment/e2e-test-kubeseal-webgui --timeout=240s
         timeout-minutes: 5
-      - name: Debug on rollout failure
-        if: failure()
-        run: |
-          echo "=== pods ==="
-          kubectl get pods --namespace kubeseal-webgui -o wide || true
-          echo "=== describe deployment ==="
-          kubectl describe deployment --namespace kubeseal-webgui e2e-test-kubeseal-webgui || true
-          echo "=== describe pods ==="
-          kubectl describe pods --namespace kubeseal-webgui -l app=kubeseal-webgui || true
-          echo "=== api logs ==="
-          kubectl logs --namespace kubeseal-webgui -l app=kubeseal-webgui -c api --tail=200 || true
-          echo "=== ui logs ==="
-          kubectl logs --namespace kubeseal-webgui -l app=kubeseal-webgui -c ui --tail=200 || true
-          echo "=== events ==="
-          kubectl get events --namespace kubeseal-webgui --sort-by=.lastTimestamp || true
       - name: Wait until ready
         run: |
-          while ! curl -f http://$(hostname -f):80/namespaces
-          do
+          HOST=$(hostname -f)
+          echo "Probing ingress at http://${HOST}:80/namespaces"
+          attempt=0
+          last_code=""
+          while true; do
+            attempt=$((attempt + 1))
+            response=$(curl -s -o /tmp/curl_body -w '%{http_code}' "http://${HOST}:80/namespaces" || echo "curl_failed")
+            if [ "$response" = "200" ]; then
+              echo "Ready after ${attempt} attempts"
+              break
+            fi
+            if [ "$response" != "$last_code" ]; then
+              echo "Attempt ${attempt}: HTTP ${response}"
+              echo "--- body ---"
+              cat /tmp/curl_body || true
+              echo "--- /body ---"
+              last_code=$response
+            fi
             sleep 5
-            echo "wait 5s"
           done
         timeout-minutes: 2
+      - name: Debug on failure
+        if: failure()
+        run: |
+          set +e
+          HOST=$(hostname -f)
+          echo "=== resolved host: ${HOST} ==="
+          echo "=== pods (kubeseal-webgui) ==="
+          kubectl get pods --namespace kubeseal-webgui -o wide
+          echo "=== describe deployment ==="
+          kubectl describe deployment --namespace kubeseal-webgui e2e-test-kubeseal-webgui
+          echo "=== describe pods ==="
+          kubectl describe pods --namespace kubeseal-webgui -l app=kubeseal-webgui
+          echo "=== api logs (current) ==="
+          kubectl logs --namespace kubeseal-webgui -l app=kubeseal-webgui -c api --tail=300
+          echo "=== api logs (previous) ==="
+          kubectl logs --namespace kubeseal-webgui -l app=kubeseal-webgui -c api --tail=300 -p
+          echo "=== ui logs (current) ==="
+          kubectl logs --namespace kubeseal-webgui -l app=kubeseal-webgui -c ui --tail=300
+          echo "=== events (kubeseal-webgui ns) ==="
+          kubectl get events --namespace kubeseal-webgui --sort-by=.lastTimestamp
+          echo "=== ingress ==="
+          kubectl get ingress --namespace kubeseal-webgui -o yaml
+          echo "=== services ==="
+          kubectl get svc --namespace kubeseal-webgui
+          echo "=== ingress-nginx pods ==="
+          kubectl get pods --namespace ingress-nginx -o wide
+          echo "=== ingress-nginx controller logs ==="
+          kubectl logs --namespace ingress-nginx -l app.kubernetes.io/component=controller --tail=200
+          echo "=== sealed-secrets pods ==="
+          kubectl get pods --namespace kube-system -l app.kubernetes.io/name=sealed-secrets -o wide
+          echo "=== direct curl to ingress ==="
+          curl -v "http://${HOST}:80/namespaces" || true
       - name: Call URL
         run: |
           curl -f http://$(hostname -f):80/namespaces

--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -61,18 +61,34 @@ jobs:
           | kubectl apply \
             -f - \
             --namespace kubeseal-webgui
+      - name: Wait for deployment to be available
+        run: |
+          kubectl rollout status --namespace kubeseal-webgui \
+            deployment/e2e-test-kubeseal-webgui --timeout=240s
+        timeout-minutes: 5
+      - name: Debug on rollout failure
+        if: failure()
+        run: |
+          echo "=== pods ==="
+          kubectl get pods --namespace kubeseal-webgui -o wide || true
+          echo "=== describe deployment ==="
+          kubectl describe deployment --namespace kubeseal-webgui e2e-test-kubeseal-webgui || true
+          echo "=== describe pods ==="
+          kubectl describe pods --namespace kubeseal-webgui -l app=kubeseal-webgui || true
+          echo "=== api logs ==="
+          kubectl logs --namespace kubeseal-webgui -l app=kubeseal-webgui -c api --tail=200 || true
+          echo "=== ui logs ==="
+          kubectl logs --namespace kubeseal-webgui -l app=kubeseal-webgui -c ui --tail=200 || true
+          echo "=== events ==="
+          kubectl get events --namespace kubeseal-webgui --sort-by=.lastTimestamp || true
       - name: Wait until ready
         run: |
-          kubectl wait --namespace kubeseal-webgui \
-            --for=condition=available \
-            --timeout=180s \
-            deployment -l app=kubeseal-webgui
           while ! curl -f http://$(hostname -f):80/namespaces
           do
             sleep 5
             echo "wait 5s"
           done
-        timeout-minutes: 3
+        timeout-minutes: 2
       - name: Call URL
         run: |
           curl -f http://$(hostname -f):80/namespaces

--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -63,12 +63,16 @@ jobs:
             --namespace kubeseal-webgui
       - name: Wait until ready
         run: |
+          kubectl wait --namespace kubeseal-webgui \
+            --for=condition=available \
+            --timeout=180s \
+            deployment -l app=kubeseal-webgui
           while ! curl -f http://$(hostname -f):80/namespaces
           do
             sleep 5
             echo "wait 5s"
           done
-        timeout-minutes: 1
+        timeout-minutes: 3
       - name: Call URL
         run: |
           curl -f http://$(hostname -f):80/namespaces

--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -34,7 +34,12 @@ jobs:
           helm repo add sealed-secrets https://bitnami-labs.github.io/sealed-secrets
           helm install sealed-secrets -n kube-system \
             --set-string fullnameOverride=sealed-secrets-controller \
+            --wait --timeout=180s \
             sealed-secrets/sealed-secrets
+          kubectl wait --namespace kube-system \
+            --for=condition=ready pod \
+            --selector=app.kubernetes.io/name=sealed-secrets \
+            --timeout=120s
       - name: Build and upload images
         run: |
           docker build -t ghcr.io/jaydee94/kubeseal-webgui/api:snapshot -f Dockerfile.api .


### PR DESCRIPTION
The "Wait until ready" step has a 1-minute timeout, which is too tight
given that the API readiness probe alone has a 20s initialDelaySeconds
plus container startup and ingress propagation. This led to flaky
failures on PRs even when the change had no runtime impact.

- Add kubectl wait for the deployment to become available before
  starting the curl loop, so we wait deterministically on readiness
  instead of relying on the timing of the curl retries.
- Raise the step-level timeout-minutes from 1 to 3 to give the cluster
  enough headroom on slower runners.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved end-to-end test workflow reliability by waiting for deployments to become available before readiness checks, increasing step timeouts, and adding an automated debug step on rollout failure that collects logs and diagnostics for faster troubleshooting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Jaydee94/kubeseal-webgui/pull/307?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->