### PR TITLE
docs: restructure documentation into docs/ folder

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,90 @@
+# Contributing to kubeseal-webgui
+
+Thanks for your interest in improving kubeseal-webgui. This document covers
+how to file issues, submit pull requests, and structure your commits so
+releases stay automatic.
+
+For local development setup (API and UI), see
+[docs/development.md](docs/development.md).
+
+## How to contribute
+
+1. Fork the repository on GitHub.
+2. Create a feature branch from `master`.
+3. Make your changes following the guidelines below.
+4. Open a pull request against `master`. Describe what you changed and why.
+
+## Reporting bugs
+
+Use the [bug report template](.github/ISSUE_TEMPLATE/bug_report.md). Please
+include:
+
+- Versions of kubeseal-webgui, the Sealed Secrets controller, and Kubernetes.
+- Steps to reproduce.
+- What you expected to happen vs. what actually happened.
+
+**Security vulnerabilities should not be filed as public issues.** Follow
+the process in [SECURITY.md](SECURITY.md) instead.
+
+## Proposing changes
+
+For anything non-trivial — new endpoints, new chart values, UI flow changes —
+open a draft pull request or discussion first so we can agree on the
+direction before you write a lot of code.
+
+## Commit messages
+
+This repository uses [Conventional Commits](https://www.conventionalcommits.org/)
+because [semantic-release](https://semantic-release.gitbook.io/) drives
+versioning, the changelog, and GitHub Releases from commit messages. The
+exact configuration lives in [`.releaserc`](.releaserc).
+
+Use one of these types as the prefix of your commit subject:
+
+| Type | When to use | Release impact |
+|---|---|---|
+| `feat` | A new feature, new endpoint, new chart value. | minor |
+| `fix` | A bug fix. | patch |
+| `perf` | A performance improvement. | patch |
+| `revert` | Reverting a previous commit. | patch |
+| `docs` | Documentation only. | none |
+| `style` | Formatting changes that do not affect behavior. | none |
+| `chore` | Maintenance work that does not fit the other categories. | patch |
+| `refactor` | Code change that neither fixes a bug nor adds a feature. | none |
+| `test` | Adding or fixing tests. | none |
+| `build` | Build-system or dependency changes. | none |
+| `ci` | CI configuration changes. | none |
+| `deps` | Dependency bumps. | patch |
+
+A commit with `BREAKING CHANGE:` in the body triggers a major release.
+
+Examples:
+
+```text
+feat: add bulk-encrypt endpoint to the API
+fix(ui): handle empty namespace list gracefully
+docs: explain auto-fetch certificate RBAC
+chore(deps): bump fastapi to 0.137
+```
+
+## Pull request checklist
+
+Before requesting review, make sure:
+
+- [ ] Tests pass locally (`poetry run pytest` for the API,
+      `npm run lint` for the UI).
+- [ ] Linters are clean (`ruff`, `black`, `isort`, `mypy` for the API;
+      `eslint` and `prettier` for the UI).
+- [ ] If you changed behavior, you updated the relevant page in `docs/`.
+- [ ] If you changed Helm values, you updated
+      [`docs/configuration.md`](docs/configuration.md) and
+      [`chart/kubeseal-webgui/values.yaml`](chart/kubeseal-webgui/values.yaml)
+      together.
+- [ ] Your commit messages follow Conventional Commits.
+
+## Code of conduct
+
+Be respectful and constructive. Harassment, personal attacks, and
+discrimination of any kind are not tolerated in issues, pull requests, or
+any other project space. Maintainers reserve the right to remove comments
+and block users that do not follow this rule.

--- a/README.md
+++ b/README.md
@@ -1,115 +1,68 @@
-# Web-Gui for Bitnami Sealed-Secrets
+# kubeseal-webgui
 
-[![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg)](https://www.python.org/) <img src="https://img.shields.io/badge/vuejs%20-%2335495e.svg?&style=for-the-badge&logo=vue.js&logoColor=%234FC08D"/> [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) [![DeepSource](https://static.deepsource.io/deepsource-badge-light-mini.svg)](https://deepsource.io/gh/Jaydee94/kubeseal-webgui/?ref=repository-badge) [![CodeQL](https://github.com/Jaydee94/kubeseal-webgui/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/Jaydee94/kubeseal-webgui/actions/workflows/codeql-analysis.yml)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![CodeQL](https://github.com/Jaydee94/kubeseal-webgui/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/Jaydee94/kubeseal-webgui/actions/workflows/codeql-analysis.yml)
+[![Latest release](https://img.shields.io/github/v/release/Jaydee94/kubeseal-webgui)](https://github.com/Jaydee94/kubeseal-webgui/releases)
 
 <p align="center">
-  <img src="demo/kubeseal-webgui-logo-2025.png">
+  <img src="demo/kubeseal-webgui-logo-2025.png" alt="kubeseal-webgui logo">
 </p>
 
-## Description
-
-This is a python based webapp for using Bitnami-Sealed-Secrets in a web-gui.
-
-This app uses the kubeseal binary of the original project: <https://github.com/bitnami-labs/sealed-secrets>
-
-The docker images can be found here:
-
-* https://hub.docker.com/repository/docker/kubesealwebgui/ui
-* https://hub.docker.com/repository/docker/kubesealwebgui/api
+kubeseal-webgui is a web frontend for
+[Bitnami Sealed Secrets](https://github.com/bitnami-labs/sealed-secrets). It
+lets cluster operators encrypt Kubernetes Secrets in the browser using the
+cluster's public certificate, without exposing the `kubeseal` CLI to every
+user. The backend is FastAPI (Python 3.12), the frontend is Vue 3 + Vuetify 4,
+and the app ships as two container images plus a Helm chart on the GitHub
+Container Registry.
 
 ## Demo
 
-![KubeSeal WebGui Demo](demo/kubeseal-webgui-demo-4.6.0.gif)
+![kubeseal-webgui demo](demo/kubeseal-webgui-demo-4.6.0.gif)
 
 ## Prerequisites
 
-To use this Web-Gui you have to install [Bitnami-Sealed-Secrets](https://github.com/bitnami-labs/sealed-secrets) in your cluster first!
+- A Kubernetes cluster (1.25 or newer).
+- The [Bitnami Sealed Secrets controller](https://github.com/bitnami-labs/sealed-secrets)
+  already installed in the cluster.
+- [Helm 3.8 or newer](https://helm.sh/docs/intro/install/).
 
-## Installation
-
-You can use the helm chart which is included inside this repository to install kubseal-webgui.
-
-You can install the chart directly from the GitHub Container Registry as an OCI artifact:
+## Quickstart
 
 ```bash
-# Make sure to configure all required values (with helm's --set argument) documented in our helm Chart before installing.
-helm install kubeseal-webgui oci://ghcr.io/jaydee94/kubeseal-webgui/charts/kubeseal-webgui --namespace <namespacename>
+helm install kubeseal-webgui \
+  oci://ghcr.io/jaydee94/kubeseal-webgui/charts/kubeseal-webgui \
+  --namespace kubeseal-webgui \
+  --create-namespace
 ```
 
-## Usage
+See [docs/installation.md](docs/installation.md) for ingress, OpenShift route,
+and certificate options.
 
-Mount the public certificate of your sealed secrets controller to `/kubeseal-webgui/cert/kubeseal-cert.pem` in the container.
+## Documentation
 
-Please use the [helm chart](https://github.com/Jaydee94/kubeseal-webgui/tree/master/chart/kubeseal-webgui) which is included in this repository.
+- [Installation](docs/installation.md) — Helm install, ingress, OpenShift route,
+  certificate setup.
+- [Configuration](docs/configuration.md) — full Helm values reference and API
+  environment variables.
+- [Architecture](docs/architecture.md) — how the UI, API, and kubeseal binary
+  fit together; API endpoints; RBAC.
+- [Development](docs/development.md) — local setup for the API and UI, running
+  tests, building images, end-to-end testing with KinD.
+- [Troubleshooting](docs/troubleshooting.md) — common errors and how to fix
+  them.
+- [Helm chart README](chart/kubeseal-webgui/README.md) — chart-specific TL;DR.
+- [Security policy](SECURITY.md) — supported versions and how to report a
+  vulnerability.
+- [Release history and upgrade notes](https://github.com/Jaydee94/kubeseal-webgui/releases) —
+  every version is documented as a GitHub Release.
 
-## Upgrade from 2.0.X to 2.1.0
+## Contributing
 
-When upgrading to `2.1.0` make sure that you also update the helm chart for installing kubeseal-webgui.
-The application reads namespaces from current kubernetes cluster and needs to have access to list them.
-If your default serviceaccount has this RBAC rule already you could disable `serviceaccount.create` in the `values.yaml` of the helm chart.
+Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for the
+workflow (Conventional Commits drive the release process) and
+[docs/development.md](docs/development.md) for local setup.
 
-## Upgrade from 2.0.X to 3.0.X
+## License
 
-When upgrading to `3.0.X` you dont need to deploy a ingress route to the api. The nginx serving the ui will proxy the requests to the api.
-You can use the new helm chart located inside the `chart` folder to deploy the new kubseal-webgui version.
-
-## Upgrade from 4.0.X to 4.1.X
-
-When upgrading from `4.0.X` to `4.1.X` you need to use the provided helm chart in version `>=5.0.0` **if you use the autofetch certificate feature**.
-This is because the autofetch certificate functionality is no longer executed as an initContainer.
-The api container will fetch the certificate from the sealed-secrets controller on application startup.
-
-### Get Public-Cert from sealed-secrets controller
-
-(Login to your kubernetes cluster first)
-
-`kubeseal --fetch-cert --controller-name <your-sealed-secrets-controller> --controller-namespace <your-sealed-secrets-controller-namespace> > kubeseal-cert.pem`
-
-# Contribute
-
-## Working on the API
-
-### Requirements
-
-* Make sure you have Python 3.12 installed.
-
-#### Setup API
-
-* Clone this repository and run `cd api`.
-* `python3 -m venv venv` (to create a virtual environment called `venv` that doesn't interfere with other projects)
-* `source venv/bin/activate` (to activate the virtual environment)
-* `python -m pip install .` (to install all required packages for this project)
-* `pytest` (should run all tests successfully)
-
-### Local API testing
-
-* Running uvicorn server
-
-  ```bash
-  MOCK_ENABLED=true poetry run uvicorn kubeseal_webgui_api.app:app --port 5000 --log-config config/logging_config.yaml
-  ```
-
-  or use a container and set the environment variables there
-
-  ```bash
-  docker build -t api -f Dockerfile.api .
-  docker run --rm -t \
-   -p 5000:5000 \
-   -e MOCK_ENABLED=TRUE \
-   -e KUBESEAL_CERT=/tmp/cert.pem \
-   api
-  ```
-
-## Working on the UI
-
-### Setup UI
-
-* Clone this repository and run `cd ui`.
-* You can either use `yarn` or `npm` for the following commands.
-* `yarn install` to install all dependencies
-* `npm install` to install all dependencies
-
-### Local UI testing
-
-* `yarn dev` to compile and start HTTP server on `port 8080` with hot-reloads for development
-* `npm run dev` to compile and start HTTP server on `port 8080` with hot-reloads for development
+Apache 2.0. See [LICENSE](LICENSE) and [NOTICE](NOTICE).

--- a/api/README.md
+++ b/api/README.md
@@ -1,3 +1,14 @@
-# API of kubeseal-webgui
+# kubeseal-webgui API
 
-This backend is used to encrypt secrets with the kubeseal binary.
+FastAPI backend that wraps the [`kubeseal`](https://github.com/bitnami-labs/sealed-secrets)
+binary. It exposes the encryption operation, plus a couple of helpers for
+listing namespaces and existing `SealedSecret` objects, as a small HTTP API.
+
+OpenAPI documentation is served at `/docs` when the API is running.
+
+## More documentation
+
+- Architecture and request flow: [../docs/architecture.md](../docs/architecture.md)
+- Running and testing locally: [../docs/development.md#api-python--fastapi](../docs/development.md#api-python--fastapi)
+- Environment variables: [../docs/configuration.md#api-environment-variables](../docs/configuration.md#api-environment-variables)
+- Container build: [../Dockerfile.api](../Dockerfile.api)

--- a/chart/kubeseal-webgui/README.md
+++ b/chart/kubeseal-webgui/README.md
@@ -1,73 +1,46 @@
-# Kubeseal-Webgui Helm Chart
+# kubeseal-webgui Helm chart
 
-* Installs the python based webapp for kubeseal-webgui
+Helm chart for deploying [kubeseal-webgui](https://github.com/Jaydee94/kubeseal-webgui)
+to a Kubernetes cluster.
+
+For a step-by-step install (with ingress, OpenShift route, and certificate
+options), see [docs/installation.md](../../docs/installation.md).
+For the full Helm values reference, see
+[docs/configuration.md](../../docs/configuration.md#helm-values).
 
 ## TL;DR
-```console
-helm install kubeseal-webgui oci://ghcr.io/jaydee94/kubeseal-webgui/charts/kubeseal-webgui --namespace <namespacename>
 
-# with ingress and autofetch certificate
-helm install kubeseal-webgui oci://ghcr.io/jaydee94/kubeseal-webgui/charts/kubeseal-webgui --namespace <namespacename> --set ingress.enabled=true --set api.url="http://kubeseal-webgui.example.com" --set sealedSecrets.autoFetchCert=true
+```bash
+helm install kubeseal-webgui \
+  oci://ghcr.io/jaydee94/kubeseal-webgui/charts/kubeseal-webgui \
+  --namespace kubeseal-webgui \
+  --create-namespace
 ```
 
-## Upgrade from 5.X.X to 6.X.X
+With an ingress and auto-fetched certificate:
 
-**IMAGES have been moved to GitHub Container Registry!!!**
-
-Container Images are now uploaded to the GitHub Registry instead of DockerHub.
-
-[API-Image](https://github.com/Jaydee94/kubeseal-webgui/pkgs/container/kubeseal-webgui%2Fapi)
-
-[UI-Image](https://github.com/Jaydee94/kubeseal-webgui/pkgs/container/kubeseal-webgui%2Fui)
-
-## Uninstalling the Chart
-
-```console
-To uninstall/delete the my-release deployment:
-
-helm uninstall kubeseal-webgui kubesealwebgui/kubeseal-webgui --namespace <namespacename>
+```bash
+helm install kubeseal-webgui \
+  oci://ghcr.io/jaydee94/kubeseal-webgui/charts/kubeseal-webgui \
+  --namespace kubeseal-webgui --create-namespace \
+  --set ingress.enabled=true \
+  --set ingress.hostname=kubeseal-webgui.example.com \
+  --set api.url=https://kubeseal-webgui.example.com \
+  --set sealedSecrets.autoFetchCert=true
 ```
 
-The command removes all the Kubernetes components associated with the chart and deletes the release.
+## Uninstalling
 
-## Configuration
+```bash
+helm uninstall kubeseal-webgui --namespace kubeseal-webgui
+```
 
-| Parameter                                 | Description                                       | Default                                |
-|-------------------------------------------|---------------------------------------------------|----------------------------------------|
-| `replicaCount`                            | Number of nodes                                   | `1`                                    |
-| `annotations`                             | Optional annotations for the pods                 | `{}`                                   |
-| `api.image.repository`                    | Image-Repository and name of the api image.       | `ghcr.io/jaydee94/kubeseal-webgui/api` |
-| `api.image.tag`                           | Image Tag of the api image.                       | `4.5.4`                                |
-| `api.environment`                         | Additional env variables for the api image.       | `{}`                                   |
-| `api.loglevel`                            | Loglevel for the api image.                       | `INFO`                                 |
-| `ui.image.repository`                     | Image-Repository and name of the ui image.        | `ghcr.io/jaydee94/kubeseal-webgui/ui`  |
-| `ui.image.tag`                            | Image Tag of the ui image.                        | `4.5.4`                                |
-| `image.pullPolicy`                        | Image Pull Policy                                 | `Always`                               |
-| `imagePullSecrets`                        | Image pull secrets for private registries.        | `[]`                                   |
-| `nameOverride`                            | Name-Override for the objects                     | `""`                                   |
-| `fullnameOverride`                        | Fullname-Override for the objects                 | `""`                                   |
-| `customServiceAccountName`                | Optionallyn define your own serviceaccount to use | `true`                                 |
-| `tolerations`                             | Add tolerations to the deployment.                | `[]`                                   |
-| `affinity`                                | Add affinity rules to the deployment.             | `{}`                                   |
-| `nodeSelector`                            | Add a nodeSelector to the deployment.             | `{}`                                   |
-| `displayName`                             | Optional display name for the kubeseal instance   | `""`                                   |
-| `resources.limits.cpu`                    | Limits CPU                                        | ``                                     |
-| `resources.limits.memory`                 | Limits memory                                     | `256Mi`                                |
-| `resources.requests.cpu`                  | Requests CPU                                      | `20m`                                  |
-| `resources.requests.memory`               | Requests memory                                   | `20m`                                  |
-| `ingress.enabled`                         | Enable an ingress route                           | `false`                                |
-| `ingress.annotations`                     | Additional annotations for the ingress object.    | `{}`                                   |
-| `ingress.ingressClassName`                | Additional ingressClassName.                      | `""`                                   |
-| `ingress.hostname`                        | The hostname for the ingress route                | `kubeseal-webgui.example.com`          |
-| `ingress.tls.enabled`                     | Enable TLS for the ingress route                  | `false`                                |
-| `ingress.tls.secretName`                  | The secret name for private and public key        | `""`                                   |
-| `route.enabled`                           | Deploy OpenShift route                            | `false`                                |
-| `route.hostname`                          | Set Hostname of the route                         | `""`                                   |
-| `route.tls.enabled`                       | Enable/Disable TLS for OpenShift Route            | `true`                                 |
-| `route.tls.termination`                   | TLS Termination of the route                      | `""`                                   |
-| `route.tls.insecureEdgeTerminationPolicy` | TLS insecureEdgeTerminationPolicy of the route    | `""`                                   |
-| `sealedSecrets.autoFetchCert`             | Load the cert from the Controller on start        | `false`                                |
-| `sealedSecrets.controllerName`            | Deployment name of the Controller                 | `sealed-secrets-controller`            |
-| `sealedSecrets.controllerNamespace`       | Namespace the Controller resides in               | `kube-system`                          |
-| `sealedSecrets.cert`                      | Public-Key of your SealedSecrets controller       | `""`                                   |
-| `api.environment`                         | Additional API environment variables              | `{}`                                   |
+This removes every Kubernetes object created by the chart. The namespace is
+not deleted automatically.
+
+## More documentation
+
+- [Installation guide](../../docs/installation.md)
+- [Configuration reference](../../docs/configuration.md)
+- [Architecture](../../docs/architecture.md)
+- [Troubleshooting](../../docs/troubleshooting.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,128 @@
+# Architecture
+
+kubeseal-webgui is a thin web frontend around the
+[`kubeseal`](https://github.com/bitnami-labs/sealed-secrets) CLI. It runs as
+two containers in a single pod and never stores anything: secrets are encrypted
+in-flight using the Sealed Secrets controller's public certificate, and the
+encrypted result is returned to the browser as JSON.
+
+## Overview
+
+```mermaid
+flowchart LR
+    Browser -->|HTTPS / static files + /api/*| Nginx
+    subgraph Pod["Pod (kubeseal-webgui)"]
+        Nginx["UI container<br/>nginx + Vue SPA"]
+        API["API container<br/>FastAPI + kubeseal binary"]
+        Nginx -->|reverse proxy| API
+    end
+    API -.->|kubectl list namespaces<br/>kubectl get sealedsecrets| K8s["Kubernetes API"]
+    API -.->|fetch public cert<br/>(optional, on startup)| Controller["Sealed Secrets controller"]
+```
+
+The browser only ever talks to the UI container. The UI container's nginx
+reverse-proxies a fixed set of paths to the API container on `localhost:5000`.
+The API container shells out to the local `kubeseal` binary to perform the
+encryption.
+
+## Components
+
+### UI container
+
+- Base image: [`quay.io/nginx/nginx-unprivileged`](https://quay.io/repository/nginx/nginx-unprivileged) (Alpine).
+- Built from `Dockerfile.ui`. The build stage compiles the Vue 3 + Vuetify 4
+  SPA with Vite; the runtime stage copies the static bundle into the nginx
+  image.
+- Listens on port 8080 (IPv4 and IPv6).
+- Reverse-proxies the API routes to the in-pod API:
+
+  ```nginx
+  location ~ /(sealed-secrets|secrets|namespaces|config|docs|openapi.json)(/.*)?$ {
+      proxy_pass http://localhost:5000;
+  }
+  ```
+
+  See [`ui/nginx-default.conf`](../ui/nginx-default.conf).
+- An entrypoint hook in `ui/hooks/` renders `api.url` into a `config.json`
+  that the SPA fetches at startup. This lets the same image be deployed to
+  any environment without rebuilding.
+
+### API container
+
+- Base image: `python:3.12-slim-bookworm`.
+- Built from `Dockerfile.api`. A first build stage downloads the `kubeseal`
+  binary (version pinned via the `KUBESEAL_VERSION` build arg, currently
+  `0.36.6`); the runtime stage installs the Python package and copies the
+  binary in.
+- Runs `uvicorn` against `kubeseal_webgui_api.app:app` on port 5000.
+- On startup, optionally fetches the controller's public certificate (see
+  `fetch_sealed_secrets_cert` in
+  [`api/kubeseal_webgui_api/app_config.py`](../api/kubeseal_webgui_api/app_config.py)).
+
+### Sealed Secrets controller (external)
+
+The Sealed Secrets controller is **not** part of this chart. It must already
+be installed in the target cluster. kubeseal-webgui only needs its public
+certificate to encrypt secrets; only the controller can decrypt them.
+
+## Request flow: sealing a secret
+
+1. The user opens the UI in a browser. The SPA loads `config.json` to discover
+   the API URL.
+2. The SPA calls `GET /namespaces` to populate the namespace selector.
+3. The user enters a secret name, namespace, scope, and one or more
+   key/value pairs, then submits.
+4. The SPA sends `POST /secrets` with the payload as JSON.
+5. The API container writes a temporary YAML representation of the secret and
+   invokes `kubeseal --raw` (or equivalent) using the public certificate at
+   `KUBESEAL_CERT`.
+6. The API returns the encrypted key/value pairs as JSON. The SPA renders
+   them as a copy-paste-ready `SealedSecret` manifest.
+
+No secret data is ever persisted by kubeseal-webgui. The encryption is
+deterministic only with respect to the controller's key pair: the same
+plaintext encrypted twice produces two different ciphertexts, but both are
+decryptable by the controller.
+
+## API endpoints
+
+| Method | Path | Description | Source |
+|---|---|---|---|
+| `GET` | `/` | Health check. Returns `{"status": "Kubeseal-WebGui API"}`. | `app.py` |
+| `GET` | `/config` | Reports the `kubeseal` binary version and other static config. | `routers/config.py` |
+| `GET` | `/namespaces` | Lists namespaces visible to the service account. | `routers/kubernetes.py` |
+| `GET` | `/sealed-secrets/{namespace}` | Lists existing `SealedSecret` objects in a namespace. Only enabled when `enableExistingSealedSecretLoading=true`. | `routers/kubernetes.py` |
+| `POST` | `/secrets` | Encrypts a payload and returns the encrypted key/value pairs. | `routers/kubeseal.py` |
+
+OpenAPI documentation is served at `/docs` (Swagger UI) and `/openapi.json`
+when the API is reachable.
+
+## RBAC
+
+The chart ships a `ClusterRole` named `kubeseal-webgui-list-namespaces`
+([`clusterrole.yaml`](../chart/kubeseal-webgui/templates/clusterrole.yaml))
+that grants:
+
+- `list` on core `namespaces`
+- `get`, `list` on `sealedsecrets.bitnami.com`
+
+If you bring your own `ServiceAccount` via `customServiceAccountName`, you
+must grant equivalent permissions yourself.
+
+## Mock mode
+
+Setting `MOCK_ENABLED=true` swaps the Kubernetes client and `kubeseal`
+invocations for in-memory mocks
+(see `mock_namespace_resolver.py` and `mock_sealed_secret_resolver.py` next
+to `routers/kubernetes.py`). This lets you run the API locally without a
+cluster or controller — useful when developing the UI or the API itself.
+
+## Image distribution
+
+Container images are published to the GitHub Container Registry:
+
+- `ghcr.io/jaydee94/kubeseal-webgui/api`
+- `ghcr.io/jaydee94/kubeseal-webgui/ui`
+
+The Helm chart is published as an OCI artifact to
+`oci://ghcr.io/jaydee94/kubeseal-webgui/charts/kubeseal-webgui`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,114 @@
+# Configuration
+
+This page is the authoritative reference for everything you can tune in
+kubeseal-webgui: Helm values, API environment variables, and the UI's
+runtime configuration.
+
+The values listed here are kept in sync with the actual defaults in
+[`chart/kubeseal-webgui/values.yaml`](../chart/kubeseal-webgui/values.yaml).
+If anything looks out of date, the YAML file is the source of truth.
+
+## Helm values
+
+### Image and replicas
+
+| Parameter | Description | Default |
+|---|---|---|
+| `replicaCount` | Number of pod replicas. | `1` |
+| `annotations` | Additional pod annotations. | `{}` |
+| `api.image.repository` | API image repository. | `ghcr.io/jaydee94/kubeseal-webgui/api` |
+| `api.image.tag` | API image tag. | Matches chart `appVersion` (see [Chart.yaml](../chart/kubeseal-webgui/Chart.yaml)). |
+| `ui.image.repository` | UI image repository. | `ghcr.io/jaydee94/kubeseal-webgui/ui` |
+| `ui.image.tag` | UI image tag. | Matches chart `appVersion` (see [Chart.yaml](../chart/kubeseal-webgui/Chart.yaml)). |
+| `image.pullPolicy` | Image pull policy. | `Always` |
+| `imagePullSecrets` | Image pull secrets for private registries. | `[]` |
+| `nameOverride` | Override the chart name component of object names. | `""` |
+| `fullnameOverride` | Override the full release name. | `""` |
+| `displayName` | Optional display name for this kubeseal-webgui instance. | `""` |
+
+### Service account and RBAC
+
+| Parameter | Description | Default |
+|---|---|---|
+| `customServiceAccountName` | Use an existing `ServiceAccount` instead of the one shipped with the chart. The account must be able to list namespaces. Leave empty to use the bundled `ServiceAccount` and `ClusterRole`. | `""` |
+
+The bundled `ClusterRole`
+([`clusterrole.yaml`](../chart/kubeseal-webgui/templates/clusterrole.yaml))
+grants `list` on `namespaces` and `get`/`list` on
+`sealedsecrets.bitnami.com`.
+
+### Networking
+
+#### Ingress
+
+| Parameter | Description | Default |
+|---|---|---|
+| `ingress.enabled` | Create an `Ingress` object. | `false` |
+| `ingress.annotations` | Additional annotations on the `Ingress`. | `{}` |
+| `ingress.ingressClassName` | `ingressClassName` to set on the `Ingress`. | `""` |
+| `ingress.hostname` | Hostname for the ingress route. | `kubeseal-webgui.example.com` |
+| `ingress.tls.enabled` | Enable TLS on the ingress route. | `false` |
+| `ingress.tls.secretName` | Name of the TLS secret (must exist in the release namespace). | `""` |
+
+#### OpenShift Route
+
+| Parameter | Description | Default |
+|---|---|---|
+| `route.enabled` | Create an OpenShift `Route`. | `false` |
+| `route.hostname` | Hostname of the route. Empty lets OpenShift assign one. | `""` |
+| `route.tls.enabled` | Enable TLS on the route. | `true` |
+| `route.tls.termination` | TLS termination mode (`edge`, `reencrypt`, `passthrough`). | `edge` |
+| `route.tls.insecureEdgeTerminationPolicy` | What to do with HTTP traffic (`None`, `Allow`, `Redirect`). | `None` |
+
+### Sealed-Secrets controller
+
+| Parameter | Description | Default |
+|---|---|---|
+| `sealedSecrets.autoFetchCert` | Fetch the controller's public certificate on API startup. | `false` |
+| `sealedSecrets.controllerName` | Deployment name of the Sealed Secrets controller. | `sealed-secrets-controller` |
+| `sealedSecrets.controllerNamespace` | Namespace of the Sealed Secrets controller. | `kube-system` |
+| `sealedSecrets.cert` | Public certificate of the controller, provided inline (used when `autoFetchCert=false`). | `""` |
+| `enableExistingSealedSecretLoading` | UI feature flag: allow importing keys from existing `SealedSecret` objects in a namespace. | `false` |
+
+### Resources, scheduling, and API options
+
+| Parameter | Description | Default |
+|---|---|---|
+| `resources.limits.cpu` | CPU limit. | unset |
+| `resources.limits.memory` | Memory limit. | `256Mi` |
+| `resources.requests.cpu` | CPU request. | `20m` |
+| `resources.requests.memory` | Memory request. | `256Mi` |
+| `tolerations` | Pod tolerations. | `[]` |
+| `affinity` | Pod affinity rules. | `{}` |
+| `nodeSelector` | Pod node selector. | `{}` |
+| `api.url` | Public URL of the API as seen by the browser. Rendered into the UI's `config.json` ConfigMap. | `http://localhost:8080` |
+| `api.loglevel` | Log level for the API container (`DEBUG`, `INFO`, `WARNING`, `ERROR`). | `INFO` |
+| `api.environment` | Additional environment variables for the API container as a map. | `{}` |
+
+## API environment variables
+
+These are read directly by the API process and can be set via
+`api.environment` in the Helm values. Source:
+[`api/kubeseal_webgui_api/app_config.py`](../api/kubeseal_webgui_api/app_config.py).
+
+| Variable | Description | Default |
+|---|---|---|
+| `KUBESEAL_BINARY` | Absolute path to the `kubeseal` executable inside the container. | `/tmp/kubeseal` (set in `Dockerfile.api`) |
+| `KUBESEAL_CERT` | Path to the controller's public certificate. | `/kubeseal-webgui/cert/kubeseal-cert.pem` |
+| `KUBESEAL_AUTOFETCH` | Set to `true` to fetch the certificate from the controller on startup. Set by the chart when `sealedSecrets.autoFetchCert=true`. | `false` |
+| `KUBESEAL_CONTROLLER_NAME` | Deployment name of the Sealed Secrets controller (used when auto-fetching). | `sealed-secrets-controller` |
+| `KUBESEAL_CONTROLLER_NAMESPACE` | Namespace of the Sealed Secrets controller (used when auto-fetching). | `sealed-secrets` in the API code, overridden to match `sealedSecrets.controllerNamespace` by the chart. |
+| `MOCK_ENABLED` | Replace the Kubernetes client and `kubeseal` invocations with in-memory mocks. Useful for local development without a cluster. | `false` |
+
+## UI configuration
+
+The UI is a static SPA. At container startup, an entrypoint hook renders
+`api.url` into a `config.json` file served alongside the bundled HTML, so the
+browser knows where to find the API.
+
+You only need to set one value:
+
+- `api.url`: the public URL of the API as the browser sees it. With the
+  bundled chart this is usually the same URL as the UI itself, because the
+  UI's nginx reverse-proxies API paths to the in-pod API container (see
+  [`ui/nginx-default.conf`](../ui/nginx-default.conf)).

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,178 @@
+# Development
+
+This guide covers running kubeseal-webgui on your laptop: API in Python, UI in
+Node, plus an end-to-end loop on a local KinD cluster.
+
+If you only want to install the released images on a real cluster, see
+[installation.md](installation.md) instead.
+
+## Prerequisites
+
+- [Python 3.12](https://www.python.org/) (the API targets 3.12 exactly).
+- [Poetry](https://python-poetry.org/) for managing the API's Python
+  dependencies.
+- [Node.js](https://nodejs.org/) — version `^20.19.0` or `>=22.12.0`
+  (matches `ui/package.json`).
+- [Docker](https://docs.docker.com/get-docker/) for building images.
+- [kubectl](https://kubernetes.io/docs/tasks/tools/) and
+  [Helm 3.8+](https://helm.sh/docs/intro/install/).
+- [KinD](https://kind.sigs.k8s.io/) (optional, for the end-to-end loop).
+
+## API (Python / FastAPI)
+
+### Setup
+
+```bash
+cd api
+python3 -m venv .venv
+source .venv/bin/activate
+pip install poetry
+poetry install
+```
+
+`poetry install` installs both runtime and development dependencies declared
+in `pyproject.toml` (including `pytest`, `ruff`, `mypy`, and `httpx` for
+tests).
+
+### Run locally
+
+```bash
+MOCK_ENABLED=true \
+  poetry run uvicorn kubeseal_webgui_api.app:app \
+    --port 5000 \
+    --log-config config/logging_config.yaml
+```
+
+`MOCK_ENABLED=true` replaces the Kubernetes client and `kubeseal` invocations
+with in-memory mocks, so you can develop without a cluster. See
+[architecture.md](architecture.md#mock-mode) for details.
+
+The API is then available at `http://localhost:5000`. Swagger UI is at
+`http://localhost:5000/docs`.
+
+### Tests
+
+```bash
+poetry run pytest
+```
+
+Markers defined in `pyproject.toml`:
+
+- `cluster`: tests that need a real Kubernetes cluster.
+- `container`: tests that need to run inside the API container.
+
+Skip both for a fast unit-test run:
+
+```bash
+poetry run pytest -m "not cluster and not container"
+```
+
+### Linting and formatting
+
+```bash
+poetry run ruff check .
+poetry run black --check .
+poetry run isort --check .
+poetry run mypy .
+```
+
+`ruff`, `black`, `isort`, and `mypy` are configured in `pyproject.toml`.
+
+## UI (Vue 3 / Vite)
+
+### Setup
+
+```bash
+cd ui
+npm install
+```
+
+This project uses npm. There is no `yarn.lock`; do not use Yarn.
+
+### Run locally
+
+```bash
+npm run dev
+```
+
+Vite serves the SPA on `http://localhost:8080` with hot reload. By default it
+expects the API at `http://localhost:5000` (set in
+`src/composables/useConfig.js` or equivalent — check `public/config.json` for
+the runtime value).
+
+### Build for production
+
+```bash
+npm run build
+```
+
+Outputs the production bundle to `ui/dist/`, which is what `Dockerfile.ui`
+copies into the nginx image.
+
+### Linting and formatting
+
+```bash
+npm run lint     # eslint, auto-fixes where possible
+npm run format   # prettier, writes to src/
+```
+
+## Building the container images
+
+```bash
+docker build -f Dockerfile.api -t kubeseal-webgui-api:dev .
+docker build -f Dockerfile.ui  -t kubeseal-webgui-ui:dev  .
+```
+
+Both builds are multi-stage:
+
+- `Dockerfile.api` downloads the `kubeseal` binary in the first stage
+  (version pinned via the `KUBESEAL_VERSION` build arg) and installs the
+  Python package in the second.
+- `Dockerfile.ui` runs `npm run build` in the first stage and serves the
+  output via nginx in the second.
+
+To run the API container against a real cluster's kubeconfig:
+
+```bash
+docker run --rm -t \
+  -p 5000:5000 \
+  -e MOCK_ENABLED=true \
+  -e KUBESEAL_CERT=/tmp/cert.pem \
+  kubeseal-webgui-api:dev
+```
+
+## End-to-end testing with KinD
+
+A helper script bootstraps a complete local environment:
+
+```bash
+./kind-setup.sh
+```
+
+The script:
+
+1. Creates a KinD cluster named `chart-testing` (dual-stack, ingress-ready).
+2. Installs the Sealed Secrets controller into `kube-system`.
+3. Installs `ingress-nginx`.
+4. Builds the local API and UI images and loads them into the cluster.
+5. Renders the Helm chart with snapshot tags and applies it.
+6. Creates several test namespaces and `SealedSecret` objects, then exercises
+   the API to verify the deployment.
+
+After the script finishes, the UI is reachable at
+`http://$(hostname -f):7180`.
+
+## Continuous integration
+
+GitHub Actions workflows live under
+[`.github/workflows/`](../.github/workflows/). The most relevant ones are:
+
+- `main.yml`: lint, tests, basic builds on every push and PR.
+- `frontend-tests.yml`: UI test suite.
+- `kind.yaml`: end-to-end test on a KinD cluster (uses `kind-setup.sh`).
+- `codeql-analysis.yml`: static analysis.
+- `container-security-scan.yml`: image vulnerability scan.
+- `ghcr-build.yml`: build and push container images to GHCR on release.
+- `helm-release.yml`: package and push the Helm chart to GHCR on release.
+- `semantic-release.yml`: derive the next version and create a GitHub Release
+  from Conventional Commit messages (see [CONTRIBUTING.md](../CONTRIBUTING.md)).

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,132 @@
+# Installation
+
+This guide walks through deploying kubeseal-webgui to a Kubernetes cluster using
+the bundled Helm chart.
+
+For local development on your laptop, see [development.md](development.md).
+For a full list of tunable values, see [configuration.md](configuration.md).
+
+## Prerequisites
+
+- A Kubernetes cluster (1.25 or newer).
+- The [Bitnami Sealed Secrets controller](https://github.com/bitnami-labs/sealed-secrets)
+  already installed in the cluster. kubeseal-webgui does not install the
+  controller itself; it only encrypts secrets against the controller's public
+  certificate.
+- [Helm 3.8 or newer](https://helm.sh/docs/intro/install/) (required for the OCI
+  installer).
+- `kubectl` configured for the target cluster.
+- An ingress controller (for `Ingress`) or OpenShift (for `Route`) if you want
+  to expose the UI outside the cluster.
+
+## Install with Helm (OCI)
+
+The chart is published as an OCI artifact to the GitHub Container Registry:
+
+```bash
+helm install kubeseal-webgui \
+  oci://ghcr.io/jaydee94/kubeseal-webgui/charts/kubeseal-webgui \
+  --namespace kubeseal-webgui \
+  --create-namespace
+```
+
+This deploys both containers (UI + API) into a single pod behind a `ClusterIP`
+service. To reach the UI from outside the cluster, enable an ingress route or
+an OpenShift route as shown below.
+
+### With an Ingress
+
+```bash
+helm install kubeseal-webgui \
+  oci://ghcr.io/jaydee94/kubeseal-webgui/charts/kubeseal-webgui \
+  --namespace kubeseal-webgui --create-namespace \
+  --set ingress.enabled=true \
+  --set ingress.hostname=kubeseal-webgui.example.com \
+  --set api.url=https://kubeseal-webgui.example.com
+```
+
+The `api.url` value is baked into the UI's `config.json` ConfigMap and tells
+the browser where to reach the API. It must match the public URL the user types
+into their browser.
+
+To enable TLS, set `ingress.tls.enabled=true` and point `ingress.tls.secretName`
+at a TLS secret that already exists in the release namespace.
+
+### On OpenShift (Route)
+
+```bash
+helm install kubeseal-webgui \
+  oci://ghcr.io/jaydee94/kubeseal-webgui/charts/kubeseal-webgui \
+  --namespace kubeseal-webgui --create-namespace \
+  --set route.enabled=true \
+  --set api.url=https://kubeseal-webgui.apps.example.com
+```
+
+Leave `route.hostname` empty to let OpenShift assign a hostname from the
+default apps subdomain.
+
+## Sealed-Secrets certificate
+
+The API needs the controller's public certificate to encrypt secrets. There
+are two ways to provide it.
+
+### Option A: Auto-fetch from the controller
+
+```bash
+helm install kubeseal-webgui \
+  oci://ghcr.io/jaydee94/kubeseal-webgui/charts/kubeseal-webgui \
+  --namespace kubeseal-webgui --create-namespace \
+  --set sealedSecrets.autoFetchCert=true \
+  --set sealedSecrets.controllerName=sealed-secrets-controller \
+  --set sealedSecrets.controllerNamespace=kube-system
+```
+
+The API container fetches the certificate from the controller on startup. The
+chart's `ClusterRole` already grants the permissions needed to talk to the
+controller. Make sure `controllerName` and `controllerNamespace` match the
+actual deployment of your Sealed Secrets controller.
+
+### Option B: Provide the certificate manually
+
+If you cannot grant the cluster-wide RBAC required by auto-fetch, fetch the
+certificate yourself and pass it inline:
+
+```bash
+kubeseal --fetch-cert \
+  --controller-name sealed-secrets-controller \
+  --controller-namespace kube-system \
+  > kubeseal-cert.pem
+
+helm install kubeseal-webgui \
+  oci://ghcr.io/jaydee94/kubeseal-webgui/charts/kubeseal-webgui \
+  --namespace kubeseal-webgui --create-namespace \
+  --set-file sealedSecrets.cert=kubeseal-cert.pem
+```
+
+The chart renders the certificate into a Secret mounted at
+`/kubeseal-webgui/cert/kubeseal-cert.pem` inside the API container.
+
+## Verifying the install
+
+```bash
+kubectl get pods -n kubeseal-webgui
+```
+
+Once the pod is `Ready`, port-forward and hit the API health endpoint:
+
+```bash
+kubectl port-forward -n kubeseal-webgui svc/kubeseal-webgui 8080:8080
+curl http://localhost:8080/
+# {"status":"Kubeseal-WebGui API"}
+```
+
+If you enabled an ingress or route, open the configured hostname in a browser.
+
+## Uninstalling
+
+```bash
+helm uninstall kubeseal-webgui --namespace kubeseal-webgui
+```
+
+This removes all Kubernetes objects created by the chart. The namespace is
+not deleted automatically.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,101 @@
+# Troubleshooting
+
+Common problems and how to diagnose them. Each entry links to the relevant
+section of the other docs.
+
+## Auto-fetch certificate fails on startup
+
+The API container logs an error like
+`Error in run_kubeseal: cannot find sealed-secrets controller`
+or hangs in `CrashLoopBackOff` shortly after start.
+
+Most common causes:
+
+- **Controller name or namespace mismatch.** Confirm with
+  `kubectl get deploy -A | grep sealed-secrets` that the Sealed Secrets
+  controller deployment name and namespace match your `sealedSecrets.controllerName`
+  and `sealedSecrets.controllerNamespace` values.
+- **Default mismatch.** The API code defaults the controller namespace to
+  `sealed-secrets`, but the Helm chart sets it to `kube-system`. If you set
+  `KUBESEAL_AUTOFETCH=true` directly (without going through the chart), make
+  sure you also set `KUBESEAL_CONTROLLER_NAMESPACE` to the right value.
+- **Missing RBAC.** If you set `customServiceAccountName`, the service
+  account must be able to talk to the Sealed Secrets controller. Use the
+  bundled `ServiceAccount` (leave `customServiceAccountName` empty) or grant
+  equivalent permissions yourself.
+
+See [configuration.md](configuration.md#sealed-secrets-controller).
+
+## `kubeseal binary not found` or 500 errors on `POST /secrets`
+
+The API expects `kubeseal` at `KUBESEAL_BINARY`. In the published container
+image this is `/tmp/kubeseal`, baked in by `Dockerfile.api`. If you run the
+API outside the container, you must install `kubeseal` locally and either:
+
+- Place it at `/tmp/kubeseal`, or
+- Set `KUBESEAL_BINARY` to the actual path before starting the API.
+
+See [development.md](development.md#api-python--fastapi).
+
+## UI loads but says "API unreachable"
+
+The browser fetches `config.json` at startup to discover the API URL. If
+`api.url` is wrong, the SPA cannot reach the API.
+
+- If you access the UI via an ingress, set `api.url` to the **public** URL
+  the browser uses, not the in-cluster service name.
+- Inside a single-pod deployment, the UI's nginx reverse-proxies API paths
+  to `localhost:5000` automatically, so `api.url` only needs to match the
+  public hostname.
+
+See [configuration.md](configuration.md#ui-configuration).
+
+## Ingress returns 502
+
+The pod has both UI and API containers. If only one of them is `Ready`, the
+service has no healthy endpoint.
+
+```bash
+kubectl describe pod -n <namespace> -l app=kubeseal-webgui
+```
+
+Look for:
+
+- The API container failing to fetch the certificate (see above).
+- The UI container failing to render `config.json` (check the entrypoint
+  hook logs for `api.url` being unset).
+
+## OpenShift Route TLS mismatch
+
+If the browser shows a certificate warning or you see HTTP/HTTPS confusion:
+
+- `route.tls.enabled` controls whether the route terminates TLS at all.
+- `route.tls.termination` must match what the upstream service expects.
+  `edge` (the default) is correct for the bundled UI container, which speaks
+  plain HTTP on port 8080.
+- Make sure `api.url` uses the same scheme (`https://`) as the route, or
+  the browser will block mixed content.
+
+See [configuration.md](configuration.md#openshift-route).
+
+## Mock mode not engaging
+
+If you set `MOCK_ENABLED=true` but the API still tries to talk to a real
+cluster:
+
+- The variable must be set **at process start**, not later. Restart the API.
+- Casing matters less than you might think (the API treats anything except
+  the literal string `true` (case-insensitive) as `false`).
+
+See [architecture.md](architecture.md#mock-mode).
+
+## Where to find logs
+
+```bash
+kubectl logs -n <namespace> -l app=kubeseal-webgui -c api
+kubectl logs -n <namespace> -l app=kubeseal-webgui -c ui
+```
+
+API log level is controlled by `api.loglevel` (default `INFO`). Set it to
+`DEBUG` to get verbose startup output, including the resolved certificate
+path and the controller name/namespace used by auto-fetch.

--- a/ui/README.md
+++ b/ui/README.md
@@ -1,29 +1,13 @@
-# kubeseal-webgui
+# kubeseal-webgui UI
 
-## Project setup
+Vue 3 + [Vuetify 4](https://vuetifyjs.com/) single-page application, built
+with [Vite](https://vite.dev/) and served by nginx in production.
 
-```console
-npm install
-```
+The UI reads `config.json` at startup to discover the API URL, so the same
+container image can be deployed to any environment without rebuilding.
 
-### Compiles and hot-reloads for development
+## More documentation
 
-```console
-npm run dev
-```
-
-### Compiles and minifies for production
-
-```console
-npm run build
-```
-
-### Lints and fixes files
-
-```console
-npm run lint
-```
-
-### Customize configuration
-
-See [Configuration Reference](https://vitejs.dev/config/).
+- Architecture and reverse-proxy layout: [../docs/architecture.md](../docs/architecture.md)
+- Running and testing locally: [../docs/development.md#ui-vue-3--vite](../docs/development.md#ui-vue-3--vite)
+- Container build: [../Dockerfile.ui](../Dockerfile.ui)


### PR DESCRIPTION
Slim the root README to a landing page and move long-form documentation
into dedicated topic pages under docs/. Add CONTRIBUTING.md to cover the
conventional-commit workflow used by semantic-release. Replace the
chart/api/ui subdirectory READMEs with short pointer pages that link
into docs/ instead of duplicating content.

Drop:
- Outdated upgrade notes for 2.0/3.0/4.0/4.1 and chart 5->6 (version
  history lives in GitHub Releases).
- Dead DockerHub references (images live on GHCR).
- Mixed yarn/npm instructions (project uses npm).
- Mixed pip/poetry instructions (project uses Poetry).

Fix in chart README:
- Typo "Optionallyn" -> "Optionally".
- Broken uninstall code fence.
- Stale image tag 4.5.4 (values.yaml uses 4.10.0; docs now reference
  Chart.yaml appVersion instead of hardcoded versions).
- Wrong default for customServiceAccountName (true -> "").
- Wrong default for resources.requests.memory (20m -> 256Mi).
- Duplicate api.environment row.
- Missing enableExistingSealedSecretLoading value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation suite covering installation, configuration, architecture, development, and troubleshooting.
  * Reorganized project READMEs for clearer navigation and added contributor guidelines.
  * Included deployment examples, local development setup, and common issue resolution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Jaydee94/kubeseal-webgui/pull/308?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->