### PR TITLE
fix(api): work around kubernetes-client v36 Bearer token key mismatch

### DIFF
--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -153,22 +153,7 @@ jobs:
                 "https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}/api/v1/namespaces"
               head -c 500 /tmp/resp; echo
               echo "--- python load_incluster_config ---"
-              python3 -c "
-from kubernetes import client, config
-config.load_incluster_config()
-cfg = client.Configuration.get_default_copy()
-print(\"host=\", cfg.host)
-print(\"verify_ssl=\", cfg.verify_ssl)
-print(\"ssl_ca_cert=\", cfg.ssl_ca_cert)
-print(\"api_key present:\", bool(cfg.api_key))
-print(\"api_key authorization startswith bearer:\", str(cfg.api_key.get(\"authorization\",\"\"))[:20] if cfg.api_key else None)
-v1 = client.CoreV1Api()
-try:
-    ns = v1.list_namespace()
-    print(\"OK\", len(ns.items))
-except Exception as e:
-    print(\"ERR\", repr(e)[:300])
-"
+              python3 -c "from kubernetes import client, config; config.load_incluster_config(); cfg=client.Configuration.get_default_copy(); print(\"host=\",cfg.host); print(\"api_key keys:\",list(cfg.api_key.keys()) if cfg.api_key else None); v1=client.CoreV1Api(); ns=v1.list_namespace(); print(\"OK\",len(ns.items))" 2>&1 || echo "python diagnostic failed"
             ' 2>&1 || true
             echo "=== direct curl to ingress ==="
             curl -v "http://${HOST}:80/namespaces"

--- a/api/kubeseal_webgui_api/routers/kubernetes_namespace_resolver.py
+++ b/api/kubeseal_webgui_api/routers/kubernetes_namespace_resolver.py
@@ -1,7 +1,8 @@
 import logging
 
 from kubernetes import client, config
-from kubernetes.client import Configuration
+
+from kubeseal_webgui_api.routers.kubernetes_utils import fix_incluster_bearer_token
 
 LOGGER = logging.getLogger("kubeseal-webgui")
 
@@ -9,7 +10,7 @@ LOGGER = logging.getLogger("kubeseal-webgui")
 def kubernetes_namespaces_resolver() -> list[str]:
     """Retrieve a list of namespaces from current kubernetes cluster."""
     config.load_incluster_config()
-    _fix_incluster_bearer_token()
+    fix_incluster_bearer_token()
     namespaces_list = []
 
     LOGGER.info("Resolving in-cluster Namespaces")
@@ -23,12 +24,3 @@ def kubernetes_namespaces_resolver() -> list[str]:
 
     LOGGER.debug("Namespaces list %s", namespaces_list)
     return namespaces_list
-
-
-def _fix_incluster_bearer_token() -> None:
-    # kubernetes-client v36 changed auth_settings() to look for 'BearerToken',
-    # but incluster_config.py still sets 'authorization' — copy it over.
-    cfg = Configuration.get_default_copy()
-    if "authorization" in cfg.api_key and "BearerToken" not in cfg.api_key:
-        cfg.api_key["BearerToken"] = cfg.api_key["authorization"]
-        Configuration.set_default(cfg)

--- a/api/kubeseal_webgui_api/routers/kubernetes_namespace_resolver.py
+++ b/api/kubeseal_webgui_api/routers/kubernetes_namespace_resolver.py
@@ -1,6 +1,7 @@
 import logging
 
 from kubernetes import client, config
+from kubernetes.client import Configuration
 
 LOGGER = logging.getLogger("kubeseal-webgui")
 
@@ -8,6 +9,7 @@ LOGGER = logging.getLogger("kubeseal-webgui")
 def kubernetes_namespaces_resolver() -> list[str]:
     """Retrieve a list of namespaces from current kubernetes cluster."""
     config.load_incluster_config()
+    _fix_incluster_bearer_token()
     namespaces_list = []
 
     LOGGER.info("Resolving in-cluster Namespaces")
@@ -21,3 +23,12 @@ def kubernetes_namespaces_resolver() -> list[str]:
 
     LOGGER.debug("Namespaces list %s", namespaces_list)
     return namespaces_list
+
+
+def _fix_incluster_bearer_token() -> None:
+    # kubernetes-client v36 changed auth_settings() to look for 'BearerToken',
+    # but incluster_config.py still sets 'authorization' — copy it over.
+    cfg = Configuration.get_default_copy()
+    if "authorization" in cfg.api_key and "BearerToken" not in cfg.api_key:
+        cfg.api_key["BearerToken"] = cfg.api_key["authorization"]
+        Configuration.set_default(cfg)

--- a/api/kubeseal_webgui_api/routers/kubernetes_sealed_secret_resolver.py
+++ b/api/kubeseal_webgui_api/routers/kubernetes_sealed_secret_resolver.py
@@ -1,6 +1,7 @@
 import logging
 
 from kubernetes import client, config
+from kubernetes.client import Configuration
 
 from kubeseal_webgui_api.routers.models import ExistingSealedSecret
 
@@ -10,6 +11,7 @@ LOGGER = logging.getLogger("kubeseal-webgui")
 def kubernetes_sealed_secret_resolver(namespace: str) -> list[ExistingSealedSecret]:
     """Retrieve SealedSecrets and their keys for a namespace from the cluster."""
     config.load_incluster_config()
+    _fix_incluster_bearer_token()
     custom_objects_api = client.CustomObjectsApi()
 
     LOGGER.info("Resolving in-cluster SealedSecrets for namespace '%s'", namespace)
@@ -47,3 +49,12 @@ def kubernetes_sealed_secret_resolver(namespace: str) -> list[ExistingSealedSecr
         resolved_sealed_secrets.append(ExistingSealedSecret(name=name, keys=keys))
 
     return sorted(resolved_sealed_secrets, key=lambda sealed_secret: sealed_secret.name)
+
+
+def _fix_incluster_bearer_token() -> None:
+    # kubernetes-client v36 changed auth_settings() to look for 'BearerToken',
+    # but incluster_config.py still sets 'authorization' — copy it over.
+    cfg = Configuration.get_default_copy()
+    if "authorization" in cfg.api_key and "BearerToken" not in cfg.api_key:
+        cfg.api_key["BearerToken"] = cfg.api_key["authorization"]
+        Configuration.set_default(cfg)

--- a/api/kubeseal_webgui_api/routers/kubernetes_sealed_secret_resolver.py
+++ b/api/kubeseal_webgui_api/routers/kubernetes_sealed_secret_resolver.py
@@ -1,8 +1,8 @@
 import logging
 
 from kubernetes import client, config
-from kubernetes.client import Configuration
 
+from kubeseal_webgui_api.routers.kubernetes_utils import fix_incluster_bearer_token
 from kubeseal_webgui_api.routers.models import ExistingSealedSecret
 
 LOGGER = logging.getLogger("kubeseal-webgui")
@@ -11,7 +11,7 @@ LOGGER = logging.getLogger("kubeseal-webgui")
 def kubernetes_sealed_secret_resolver(namespace: str) -> list[ExistingSealedSecret]:
     """Retrieve SealedSecrets and their keys for a namespace from the cluster."""
     config.load_incluster_config()
-    _fix_incluster_bearer_token()
+    fix_incluster_bearer_token()
     custom_objects_api = client.CustomObjectsApi()
 
     LOGGER.info("Resolving in-cluster SealedSecrets for namespace '%s'", namespace)
@@ -49,12 +49,3 @@ def kubernetes_sealed_secret_resolver(namespace: str) -> list[ExistingSealedSecr
         resolved_sealed_secrets.append(ExistingSealedSecret(name=name, keys=keys))
 
     return sorted(resolved_sealed_secrets, key=lambda sealed_secret: sealed_secret.name)
-
-
-def _fix_incluster_bearer_token() -> None:
-    # kubernetes-client v36 changed auth_settings() to look for 'BearerToken',
-    # but incluster_config.py still sets 'authorization' — copy it over.
-    cfg = Configuration.get_default_copy()
-    if "authorization" in cfg.api_key and "BearerToken" not in cfg.api_key:
-        cfg.api_key["BearerToken"] = cfg.api_key["authorization"]
-        Configuration.set_default(cfg)

--- a/api/kubeseal_webgui_api/routers/kubernetes_utils.py
+++ b/api/kubeseal_webgui_api/routers/kubernetes_utils.py
@@ -1,0 +1,10 @@
+from kubernetes.client import Configuration
+
+
+def fix_incluster_bearer_token() -> None:
+    # kubernetes-client v36 changed auth_settings() to look for 'BearerToken',
+    # but incluster_config.py still sets 'authorization' — copy it over.
+    cfg = Configuration.get_default_copy()
+    if "authorization" in cfg.api_key and "BearerToken" not in cfg.api_key:
+        cfg.api_key["BearerToken"] = cfg.api_key["authorization"]
+        Configuration.set_default(cfg)


### PR DESCRIPTION
## Summary

- `kubernetes-client` v36 changed `auth_settings()` to look for `api_key['BearerToken']`, but `incluster_config.py` still sets `api_key['authorization']`
- The key mismatch causes the `Authorization` header to never be sent → Kubernetes responds 401 → `/namespaces` and `/sealed-secrets` return 500
- After `load_incluster_config()`, copy `api_key['authorization']` → `api_key['BearerToken']` when the latter is absent; the guard makes this a no-op on v35

Fixes #311

## Test Plan

- [ ] Deploy chart `6.0.13` (kubernetes-client v36) — Namespace dropdown populates correctly
- [ ] Verify `/namespaces` returns 200 with namespace list
- [ ] Verify `/sealed-secrets/<ns>` returns 200
- [ ] Confirm no regression on chart `6.0.11` (kubernetes-client v35)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed in-cluster bearer token handling for Kubernetes auth, ensuring namespace and sealed-secret operations authenticate correctly.
  * Centralized the token adjustment so both namespace listing and sealed-secret resolution benefit from the same fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->